### PR TITLE
Clean agent before building.

### DIFF
--- a/ros-catkin-build/azure-pipelines.yml
+++ b/ros-catkin-build/azure-pipelines.yml
@@ -50,7 +50,7 @@ jobs:
     BUILD_TOOL_PACKAGE: 'ros-catkin-tools'
     PYTHON_LOCATION: 'c:\opt\python27amd64'
   steps:
-  #- template: ..\common\agent-clean.yml
+  - template: ..\common\agent-clean.yml
   - template: common\checkout.yml
   - template: common\build.yml
   - template: common\symbols.yml


### PR DESCRIPTION
This is to address the out-of-space issue on CI agent.