### PR TITLE
Upstream repositories cleanup for melodic run_tests build

### DIFF
--- a/ros-catkin-build/melodic/runtests.rosinstall
+++ b/ros-catkin-build/melodic/runtests.rosinstall
@@ -1,10 +1,10 @@
 - git:
-    local-name: laser_geometry
-    uri: https://github.com/ms-iot/laser_geometry.git
+    local-name: filters
+    uri: https://github.com/ms-iot/filters.git
     version: init_windows
 - git:
-    local-name: laser_assembler
-    uri: https://github.com/ms-iot/laser_assembler.git
+    local-name: laser_geometry
+    uri: https://github.com/ms-iot/laser_geometry.git
     version: init_windows
 - git:
     local-name: diagnostics

--- a/ros-catkin-build/melodic/runtests.rosinstall
+++ b/ros-catkin-build/melodic/runtests.rosinstall
@@ -3,10 +3,6 @@
     uri: https://github.com/ms-iot/filters.git
     version: init_windows
 - git:
-    local-name: laser_geometry
-    uri: https://github.com/ms-iot/laser_geometry.git
-    version: init_windows
-- git:
     local-name: diagnostics
     uri: https://github.com/ms-iot/diagnostics.git
     version: init_windows

--- a/ros-catkin-build/melodic/runtests.rosinstall
+++ b/ros-catkin-build/melodic/runtests.rosinstall
@@ -1,18 +1,10 @@
 - git:
-    local-name: filters
-    uri: https://github.com/ms-iot/filters.git
-    version: init_windows
-- git:
     local-name: laser_geometry
     uri: https://github.com/ms-iot/laser_geometry.git
     version: init_windows
 - git:
     local-name: laser_assembler
     uri: https://github.com/ms-iot/laser_assembler.git
-    version: init_windows
-- git:
-    local-name: laser_filters
-    uri: https://github.com/ms-iot/laser_filters.git
     version: init_windows
 - git:
     local-name: diagnostics


### PR DESCRIPTION
The following repos are fully upstream'ed, so we no longer need to patch it with our `ms-iot` forks:
* https://github.com/ros-perception/laser_geometry
* https://github.com/ros-perception/laser_assembler
* https://github.com/ros-perception/laser_filters