### PR TITLE
Use ms-iot msft_ros_pkgs for Vcpkg integration

### DIFF
--- a/ros-catkin-build/azure-pipelines.yml
+++ b/ros-catkin-build/azure-pipelines.yml
@@ -11,33 +11,37 @@ jobs:
     matrix:
       melodic-ros_core:
         ROSWIN_METAPACKAGE: 'ros_core'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
       melodic-ros_base:
         ROSWIN_METAPACKAGE: 'ros_base'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
       melodic-robot:
         ROSWIN_METAPACKAGE: 'robot'
-        ROSWIN_ADDITIONAL_PACKAGE: 'navigation'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs navigation'
       melodic-perception:
         ROSWIN_METAPACKAGE: 'perception'
-        ROSWIN_ADDITIONAL_PACKAGE: 'diagnostic_updater'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs diagnostic_updater'
       melodic-navigation:
         ROSWIN_METAPACKAGE: 'navigation'
-        ROSWIN_ADDITIONAL_PACKAGE: 'diagnostic_updater'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs diagnostic_updater'
       melodic-viz:
         ROSWIN_METAPACKAGE: 'viz'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
       melodic-simulators:
         ROSWIN_METAPACKAGE: 'simulators'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
       melodic-desktop:
         ROSWIN_METAPACKAGE: 'desktop'
-        ROSWIN_ADDITIONAL_PACKAGE: 'ros_vcpkg rosserial joystick_drivers teleop_twist_joy navigation soem robotiq_2f_gripper_action_server robotiq_modbus_rtu image_transport_plugins'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs rosserial joystick_drivers teleop_twist_joy navigation soem robotiq_2f_gripper_action_server robotiq_modbus_rtu image_transport_plugins'
       melodic-desktop_full:
         ROSWIN_METAPACKAGE: 'desktop_full'
-        ROSWIN_ADDITIONAL_PACKAGE: 'ros_vcpkg rosserial joystick_drivers teleop_twist_joy navigation soem robotiq_2f_gripper_action_server robotiq_modbus_rtu ros_controllers'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs rosserial joystick_drivers teleop_twist_joy navigation soem robotiq_2f_gripper_action_server robotiq_modbus_rtu ros_controllers'
       melodic-moveit:
         ROSWIN_METAPACKAGE: 'moveit'
-        ROSWIN_ADDITIONAL_PACKAGE: 'moveit_resources moveit_visual_tools perception desktop ros_control industrial_core descartes'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs moveit_resources moveit_visual_tools perception desktop ros_control industrial_core descartes'
       melodic-cartographer_ros:
         ROSWIN_METAPACKAGE: 'cartographer_ros'
-        ROSWIN_ADDITIONAL_PACKAGE: 'cartographer_rviz'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs cartographer_rviz'
   timeoutInMinutes: 300
   pool:
     vmImage: 'windows-2019'

--- a/ros-catkin-build/melodic/build.rosinstall
+++ b/ros-catkin-build/melodic/build.rosinstall
@@ -7,6 +7,6 @@
     uri: https://github.com/ms-iot/descartes
     version: init_windows
 - git:
-    local-name: ros_vcpkg
-    uri: https://github.com/seanyen/ros_vcpkg
+    local-name: msft_ros_pkgs
+    uri: https://github.com/ms-iot/msft_ros_pkgs
     version: master


### PR DESCRIPTION
Switched to use `ms-iot\msft_ros_pkgs` for Vcpkg integration.