### PR TITLE
Fix a recent build break in viz build

### DIFF
--- a/ros-catkin-build/azure-pipelines.yml
+++ b/ros-catkin-build/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
         ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs diagnostic_updater'
       melodic-viz:
         ROSWIN_METAPACKAGE: 'viz'
-        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs roslint'
       melodic-simulators:
         ROSWIN_METAPACKAGE: 'simulators'
         ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'


### PR DESCRIPTION
The recent viz build is broken because a recent addition of `roslint` to `package.xml` which adds the inconsistent dependency graph between `rosdistro` data and the upstream source file. To work around the issue before the changes are released to `rosdistro`, I added `roslint` to fix the build.