### PR TITLE
Add component scanning for ROS and pip packages.

### DIFF
--- a/common/rospkg2cgmanifest.py
+++ b/common/rospkg2cgmanifest.py
@@ -1,0 +1,59 @@
+from catkin_pkg.packages import find_packages
+from multiprocessing import freeze_support
+from rosdistro import get_cached_distribution, get_index, get_index_url
+from subprocess import Popen, PIPE
+import os
+import sys
+import json
+
+
+def get_distro(distro_name):
+    index = get_index(get_index_url())
+    return get_cached_distribution(index, distro_name)
+
+
+def get_package_repo(distro, name):
+    return distro.repositories[distro.release_packages[name].repository_name].source_repository
+
+
+if __name__ == '__main__':
+    freeze_support()
+    if not ('ROS_SHARE_DIR' in os.environ):
+        raise ValueError('expect ROS_SHARE_DIR to be defined in os.environ')
+
+    if not ('ROS_DISTRO' in os.environ):
+        raise ValueError('expect ROS_DISTRO to be defined in os.environ')
+
+    packages = find_packages(os.environ['ROS_SHARE_DIR'])
+    distro = get_distro(os.environ['ROS_DISTRO'])
+    data = {}
+    data['version'] = 1
+    reg = data['registrations'] = []
+    for key, value in packages.iteritems():
+        try:
+            lic = value.licenses[0]
+            repo = get_package_repo(distro, value.name)
+            url = repo.url
+            version = repo.version
+            git_query = Popen(['git', 'ls-remote', url, version], stdout=PIPE, stderr=PIPE)
+            (git_status, error) = git_query.communicate()
+            if git_query.poll() == 0:
+                s_list = git_status.splitlines()
+            for line in s_list:
+                commit = line.split()[0]
+
+            reg.append({
+                'component': {
+                    'type': 'git',
+                    'git': {
+                        'name': value.name,
+                        'repositoryUrl': url,
+                        'commitHash': commit
+                    }
+                },
+                'license': str(lic),
+                'version': value.version
+            })
+        except:
+            pass
+    print json.dumps(data)

--- a/ros-catkin-build/azure-pipelines.yml
+++ b/ros-catkin-build/azure-pipelines.yml
@@ -36,6 +36,7 @@ jobs:
       melodic-desktop_full:
         ROSWIN_METAPACKAGE: 'desktop_full'
         ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs rosserial joystick_drivers teleop_twist_joy navigation soem robotiq_2f_gripper_action_server robotiq_modbus_rtu ros_controllers'
+        skipComponentGovernanceDetection: false
       melodic-moveit:
         ROSWIN_METAPACKAGE: 'moveit'
         ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs moveit_resources moveit_visual_tools perception desktop ros_control industrial_core descartes'
@@ -47,17 +48,20 @@ jobs:
     vmImage: 'windows-2019'
   variables:
     ROS_DISTRO: 'melodic'
+    ROS_SHARE_DIR: 'c:\opt\ros\melodic\x64\share'
     ROS_ETC_DIR: 'c:\opt\ros\melodic\x64\etc\ros'
     ROSDISTRO_INDEX_URL: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/index.yaml'
     ROSWIN_ROSDEP_LIST_URI: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/rosdep/sources.list.d/10-ms-iot.list'
     ROSWIN_VSTOOL: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
     BUILD_TOOL_PACKAGE: 'ros-catkin-tools'
     PYTHON_LOCATION: 'c:\opt\python27amd64'
+    skipComponentGovernanceDetection: true
   steps:
   - template: ..\common\agent-clean.yml
   - template: common\checkout.yml
   - template: common\build.yml
   - template: common\symbols.yml
+  - template: common\cgscan.yml
   - template: ..\package-build\package-build.yml
 - job: TestInstall
   dependsOn: Build
@@ -69,5 +73,7 @@ jobs:
   timeoutInMinutes: 300
   pool:
     vmImage: 'windows-2019'
+  variables:
+    skipComponentGovernanceDetection: true
   steps:
   - template: ..\package-build\package-test.yml

--- a/ros-catkin-build/common/cgscan.yml
+++ b/ros-catkin-build/common/cgscan.yml
@@ -1,0 +1,8 @@
+steps: 
+- script: |
+    call "setup.bat"
+    mkdir ..\cgscan\
+    python ..\common\rospkg2cgmanifest.py > ..\cgscan\cgmanifest.json
+    pip freeze > ..\cgscan\requirements.txt
+  workingDirectory: $(ROSWIN_CATKIN_BUILD_WORKING_DIRECTORY)
+  displayName: 'Component Governance Scanning'


### PR DESCRIPTION
Add script to enumerate the installed ROS packages and generate `cgmanifest.json` and also do a `pip freeze` to dump installed `pip` packages for component governance inventory.