### PR TITLE
[dockerized ROS] Moved the OS names into tags.

### DIFF
--- a/docker/azure-pipelines.yml
+++ b/docker/azure-pipelines.yml
@@ -5,8 +5,9 @@ jobs:
   strategy:
     matrix:
       melodic-desktop_full:
-        repository: 'public/ros/windowsservercore/melodic-desktop_full'
+        repository: 'public/ros/melodic-desktop_full'
         dockerfile: 'docker/melodic/windowsservercore/desktop-full/dockerfile'
+        tags: 'latest-servercore-ltsc2019'
   timeoutInMinutes: 240
   pool:
     vmImage: 'windows-2019'
@@ -24,4 +25,4 @@ jobs:
       repository: $(repository)
       command: 'buildAndPush'
       Dockerfile: $(dockerfile)
-      tags: 'latest'
+      tags: $(tags)


### PR DESCRIPTION
Per MCR's team feedback, we should move the OS names into tags. (One example is https://hub.docker.com/_/microsoft-dotnet-core-sdk/)