### PR TITLE
[catkin] Add ROS_PYTHON_VERSION for python conditional dependencies

### DIFF
--- a/ros-catkin-build/azure-pipelines.yml
+++ b/ros-catkin-build/azure-pipelines.yml
@@ -47,6 +47,7 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   variables:
+    ROS_PYTHON_VERSION: '2'
     ROS_DISTRO: 'melodic'
     ROS_SHARE_DIR: 'c:\opt\ros\melodic\x64\share'
     ROS_ETC_DIR: 'c:\opt\ros\melodic\x64\etc\ros'

--- a/ros-catkin-build/ros-melodic-desktop.runtests.yml
+++ b/ros-catkin-build/ros-melodic-desktop.runtests.yml
@@ -15,6 +15,7 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   variables:
+    ROS_PYTHON_VERSION: '2'
     ROS_DISTRO: 'melodic'
     ROS_ETC_DIR: 'c:\opt\ros\melodic\x64\etc\ros'
     ROSDISTRO_INDEX_URL: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/index.yaml'

--- a/ros-catkin-build/ros-melodic-desktop_full.runtests.yml
+++ b/ros-catkin-build/ros-melodic-desktop_full.runtests.yml
@@ -15,6 +15,7 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   variables:
+    ROS_PYTHON_VERSION: '2'
     ROS_DISTRO: 'melodic'
     ROS_ETC_DIR: 'c:\opt\ros\melodic\x64\etc\ros'
     ROSDISTRO_INDEX_URL: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/index.yaml'

--- a/ros-catkin-build/ros-melodic-ros_base.runtests.yml
+++ b/ros-catkin-build/ros-melodic-ros_base.runtests.yml
@@ -15,6 +15,7 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   variables:
+    ROS_PYTHON_VERSION: '2'
     ROS_DISTRO: 'melodic'
     ROS_ETC_DIR: 'c:\opt\ros\melodic\x64\etc\ros'
     ROSDISTRO_INDEX_URL: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/index.yaml'

--- a/ros-colcon-build/crystal/azure-pipelines.yml
+++ b/ros-colcon-build/crystal/azure-pipelines.yml
@@ -14,26 +14,21 @@ jobs:
     ROSWIN_METAPACKAGE: 'ALL'
     ROSWIN_ADDITIONAL_PACKAGE: 'ros_rosdeps'
     ROSWIN_VSTOOL: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
+    ROSWIN_CMAKE_INSTALL_PREFIX: 'c:/opt/ros/crystal/x64'
     BUILD_TOOL_PACKAGE: 'ros-colcon-tools'
     BUILD_TOOL_PACKAGE_VERSION: '0.0.1.1905240527'
     PYTHON_LOCATION: 'c:\opt\python37amd64'
+    ROS_PYTHON_VERSION: '3'
+    ROS_DISTRO: 'crystal'
+    ROS_ETC_DIR: 'c:\opt\ros\crystal\x64\etc\ros'
   strategy:
     matrix:
       crystal-ros_core:
         ROSWIN_METAPACKAGE: 'ros_core'
-        ROS_DISTRO: 'crystal'
-        ROS_ETC_DIR: 'c:\opt\ros\crystal\x64\etc\ros'
-        ROSWIN_CMAKE_INSTALL_PREFIX: 'c:/opt/ros/crystal/x64'
       crystal-ros_base:
         ROSWIN_METAPACKAGE: 'ros_base'
-        ROS_DISTRO: 'crystal'
-        ROS_ETC_DIR: 'c:\opt\ros\crystal\x64\etc\ros'
-        ROSWIN_CMAKE_INSTALL_PREFIX: 'c:/opt/ros/crystal/x64'
       crystal-desktop:
         ROSWIN_METAPACKAGE: 'desktop'
-        ROS_DISTRO: 'crystal'
-        ROS_ETC_DIR: 'c:\opt\ros\crystal\x64\etc\ros'
-        ROSWIN_CMAKE_INSTALL_PREFIX: 'c:/opt/ros/crystal/x64'
   steps:
   # - template: ..\..\common\agent-clean.yml
   - template: ..\common\checkout.yml

--- a/ros-colcon-build/dashing/azure-pipelines.yml
+++ b/ros-colcon-build/dashing/azure-pipelines.yml
@@ -15,6 +15,7 @@ jobs:
     ROSWIN_VSTOOL: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
     ROSWIN_CMAKE_INSTALL_PREFIX: 'c:/opt/ros/dashing/x64'
     ROSWIN_ADDITIONAL_PACKAGE: 'ros_rosdeps'
+    ROS_PYTHON_VERSION: '3'
     ROS_DISTRO: 'dashing'
     ROS_ETC_DIR: 'c:\opt\ros\dashing\x64\etc\ros'
     BUILD_TOOL_PACKAGE: 'ros-colcon-tools'

--- a/ros-colcon-build/melodic/azure-pipelines.yml
+++ b/ros-colcon-build/melodic/azure-pipelines.yml
@@ -16,18 +16,18 @@ jobs:
     BUILD_TOOL_PACKAGE: 'ros-colcon-tools'
     BUILD_TOOL_PACKAGE_VERSION: '0.0.1.1905240527'
     PYTHON_LOCATION: 'c:\opt\python37amd64'
+    ROS_PYTHON_VERSION: '3'
+    OS_DISTRO: 'melodic'
   strategy:
     matrix:
       melodic-ros_base:
         ROSWIN_METAPACKAGE: 'ros_core'
         ROSDISTRO_INDEX_URL: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/index.yaml'
-        ROS_DISTRO: 'melodic'
         ROS_ETC_DIR: 'c:\opt\ros\melodic\x64\etc\ros'
         ROSWIN_CMAKE_INSTALL_PREFIX: 'c:/opt/ros/melodic/x64'
       melodic-desktop_full:
         ROSWIN_METAPACKAGE: 'desktop_full'
         ROSDISTRO_INDEX_URL: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/index.yaml'
-        ROS_DISTRO: 'melodic'
         ROS_ETC_DIR: 'c:\opt\ros\melodic\x64\etc\ros'
         ROSWIN_CMAKE_INSTALL_PREFIX: 'c:/opt/ros/melodic/x64'
   steps:

--- a/ros-colcon-build/melodic/azure-pipelines.yml
+++ b/ros-colcon-build/melodic/azure-pipelines.yml
@@ -17,7 +17,7 @@ jobs:
     BUILD_TOOL_PACKAGE_VERSION: '0.0.1.1905240527'
     PYTHON_LOCATION: 'c:\opt\python37amd64'
     ROS_PYTHON_VERSION: '3'
-    OS_DISTRO: 'melodic'
+    ROS_DISTRO: 'melodic'
   strategy:
     matrix:
       melodic-ros_base:


### PR DESCRIPTION
A recent change in `catkin`(https://github.com/ros/catkin/pull/1025) starts to use `ROS_PYTHON_VERSION` to conditionally pick & choose Python dependencies. Consequently, the environment variables becomes mandatory to build ROS from source.