### PR TITLE
[dockerized] Prefix the container repository name as robotics.

### DIFF
--- a/docker/azure-pipelines.yml
+++ b/docker/azure-pipelines.yml
@@ -5,7 +5,7 @@ jobs:
   strategy:
     matrix:
       melodic-desktop_full:
-        repository: 'public/ros/melodic-desktop_full'
+        repository: 'public/robotics/ros/melodic-desktop_full'
         dockerfile: 'docker/melodic/windowsservercore/desktop-full/dockerfile'
         tags: 'latest-servercore-ltsc2019'
   timeoutInMinutes: 240

--- a/docker/azure-pipelines.yml
+++ b/docker/azure-pipelines.yml
@@ -5,7 +5,7 @@ jobs:
   strategy:
     matrix:
       melodic-desktop_full:
-        repository: 'public/robotics/ros/melodic-desktop_full'
+        repository: 'public/robotics-ros/melodic-desktop_full'
         dockerfile: 'docker/melodic/windowsservercore/desktop-full/dockerfile'
         tags: 'latest-servercore-ltsc2019'
   timeoutInMinutes: 240


### PR DESCRIPTION
This is to address a feedback from MCR team, which suggests to have a more generic product family name prefix in front of `ros`.