### PR TITLE
override qt_gui_core before fix gets upstream'ed.

### DIFF
--- a/ros-catkin-build/melodic/build.rosinstall
+++ b/ros-catkin-build/melodic/build.rosinstall
@@ -10,3 +10,7 @@
     local-name: msft_ros_pkgs
     uri: https://github.com/ms-iot/msft_ros_pkgs
     version: master
+- git:
+    local-name: qt_gui_core
+    uri: https://github.com/ms-iot/qt_gui_core/
+    version: windows_fix


### PR DESCRIPTION
To override the `qt_gui_core` for melodic build to rescue the build before the fix gets merged at upstream. https://github.com/ros-visualization/qt_gui_core/pull/188