### PR TITLE
Add qt_gui_core override to recover builds.

### DIFF
--- a/ros-catkin-build/melodic/runtests.rosinstall
+++ b/ros-catkin-build/melodic/runtests.rosinstall
@@ -10,3 +10,7 @@
     local-name: urdf
     uri: https://github.com/ms-iot/urdf.git
     version: init_windows
+- git:
+    local-name: qt_gui_core
+    uri: https://github.com/ms-iot/qt_gui_core/
+    version: windows_fix

--- a/ros-colcon-build/melodic/build.rosinstall
+++ b/ros-colcon-build/melodic/build.rosinstall
@@ -2,3 +2,7 @@
     local-name: geometry2
     uri: https://github.com/ms-iot/geometry2.git
     version: init_windows_msbuild_fix
+- git:
+    local-name: qt_gui_core
+    uri: https://github.com/ms-iot/qt_gui_core/
+    version: windows_fix


### PR DESCRIPTION
They are missing from this [pull request](https://github.com/ms-iot/ros-windows-build/pull/20) and required to recover the test build (and the melodic on Python3 experimental build.)