### PR TITLE
cleanup by removing staging repositories.

### DIFF
--- a/ros-colcon-build/dashing/build.rosinstall
+++ b/ros-colcon-build/dashing/build.rosinstall
@@ -5,16 +5,12 @@
 - git:
     local-name: vision_opencv
     uri: https://github.com/ms-iot/vision_opencv.git
-    version: ros2_init_windows
-- git:
-    local-name: depthimage_to_laserscan
-    uri: https://github.com/ms-iot/depthimage_to_laserscan.git
-    version: ros2_init_windows
+    version: ros2_patch
 - git:
     local-name: ros_rosdeps
     uri: https://github.com/seanyen/ros_rosdeps.git
     version: master
 - git:
     local-name: rviz
-    uri: https://github.com/seanyen/rviz.git
-    version: dashing_windows
+    uri: https://github.com/ms-iot/rviz.git
+    version: ros2_patch

--- a/ros-colcon-build/eloquent/azure-pipelines.yml
+++ b/ros-colcon-build/eloquent/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
   strategy:
     matrix:
       eloquent-ALL:
-        ROSWIN_PACKAGE_SKIP: 'gazebo_ros theora_image_transport cartographer ros_workspace depthimage_to_laserscan camera_info_manager teleop_twist_joy'
+        ROSWIN_PACKAGE_SKIP: 'gazebo_ros theora_image_transport cartographer ros_workspace camera_info_manager teleop_twist_joy'
   steps:
   # - template: ..\common\agent-clean.yml
   - template: ..\common\checkout.yml

--- a/ros-colcon-build/eloquent/build.rosinstall
+++ b/ros-colcon-build/eloquent/build.rosinstall
@@ -1,14 +1,6 @@
 - git:
-    local-name: pluginlib
-    uri: https://github.com/ms-iot/pluginlib.git
-    version: ros2_patch
-- git:
     local-name: vision_opencv
     uri: https://github.com/ms-iot/vision_opencv.git
-    version: ros2_patch
-- git:
-    local-name: image_common
-    uri: https://github.com/ms-iot/image_common.git
     version: ros2_patch
 - git:
     local-name: rviz


### PR DESCRIPTION
- Removed `ms-iot` repositories override since the patches are merged at the upstream:
  - `depthimage_to_laserscan`
  - `pluginlib`
  - `image_common`

- Consolidate the override across ROS `distro` since they are pointed to the same branches:
  - `vision_opencv`
  - `rviz`