### PR TITLE
remove vision_opencv override.

### DIFF
--- a/ros-colcon-build/dashing/build.rosinstall
+++ b/ros-colcon-build/dashing/build.rosinstall
@@ -3,10 +3,6 @@
     uri: https://github.com/eProsima/Fast-RTPS.git
     version: v1.8.0
 - git:
-    local-name: vision_opencv
-    uri: https://github.com/ms-iot/vision_opencv.git
-    version: ros2_patch
-- git:
     local-name: ros_rosdeps
     uri: https://github.com/seanyen/ros_rosdeps.git
     version: master

--- a/ros-colcon-build/eloquent/build.rosinstall
+++ b/ros-colcon-build/eloquent/build.rosinstall
@@ -1,8 +1,4 @@
 - git:
-    local-name: vision_opencv
-    uri: https://github.com/ms-iot/vision_opencv.git
-    version: ros2_patch
-- git:
     local-name: rviz
     uri: https://github.com/ms-iot/rviz.git
     version: ros2_patch


### PR DESCRIPTION
The patches for `vision_opencv` are merged just an hour ago at the upstream. :)