### PR TITLE
remove ms-iot qt_gui_core override.

### DIFF
--- a/ros-catkin-build/melodic/build.rosinstall
+++ b/ros-catkin-build/melodic/build.rosinstall
@@ -10,7 +10,3 @@
     local-name: msft_ros_pkgs
     uri: https://github.com/ms-iot/msft_ros_pkgs
     version: master
-- git:
-    local-name: qt_gui_core
-    uri: https://github.com/ms-iot/qt_gui_core/
-    version: windows_fix

--- a/ros-catkin-build/melodic/runtests.rosinstall
+++ b/ros-catkin-build/melodic/runtests.rosinstall
@@ -10,7 +10,3 @@
     local-name: urdf
     uri: https://github.com/ms-iot/urdf.git
     version: init_windows
-- git:
-    local-name: qt_gui_core
-    uri: https://github.com/ms-iot/qt_gui_core/
-    version: windows_fix

--- a/ros-colcon-build/melodic/build.rosinstall
+++ b/ros-colcon-build/melodic/build.rosinstall
@@ -2,7 +2,3 @@
     local-name: geometry2
     uri: https://github.com/ms-iot/geometry2.git
     version: init_windows_msbuild_fix
-- git:
-    local-name: qt_gui_core
-    uri: https://github.com/ms-iot/qt_gui_core/
-    version: windows_fix

--- a/ros-colcon-build/noetic/build.rosinstall
+++ b/ros-colcon-build/noetic/build.rosinstall
@@ -96,8 +96,8 @@
     version: kinetic-devel
 - git:
     local-name: qt_gui_core
-    uri: https://github.com/ms-iot/qt_gui_core/
-    version: windows_fix
+    uri: https://github.com/ros-visualization/qt_gui_core.git
+    version: kinetic-devel
 - git:
     local-name: qwt_dependency
     uri: https://github.com/ros-visualization/qwt_dependency.git


### PR DESCRIPTION
The rework [patch](https://github.com/ros-visualization/qt_gui_core/pull/188) for `qt_gui_core` is merged at the upstream.