### PR TITLE
Consolidate py3 & py2 rosdep database for ROS1 builds.

### DIFF
--- a/ros-colcon-build/melodic/azure-pipelines.yml
+++ b/ros-colcon-build/melodic/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   variables:
-    ROSWIN_ROSDEP_LIST_URI: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows_py37/rosdep/sources.list.d/10-ms-iot.list'
+    ROSWIN_ROSDEP_LIST_URI: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/rosdep/sources.list.d/10-ms-iot.list'
     ROSWIN_METAPACKAGE: 'ALL'
     ROSWIN_VSTOOL: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
     BUILD_TOOL_PACKAGE: 'ros-colcon-tools'

--- a/ros-colcon-build/noetic/azure-pipelines.yml
+++ b/ros-colcon-build/noetic/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   variables:
-    ROSWIN_ROSDEP_LIST_URI: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows_py37/rosdep/sources.list.d/10-ms-iot.list'
+    ROSWIN_ROSDEP_LIST_URI: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/rosdep/sources.list.d/10-ms-iot.list'
     ROSWIN_METAPACKAGE: 'ALL'
     ROSWIN_VSTOOL: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
     BUILD_TOOL_PACKAGE: 'ros-colcon-tools'


### PR DESCRIPTION
As there are more `Python3` convention has been discussed and implemented, I believe we should follow the same [guidance](https://github.com/ros-infrastructure/rep/pull/201) to maintain the `rosdep` database. And this pull request is part of the effort to start converge the `init_windows_py37` and `init_windows` branch.

Once I stabilize `Python3` builds for `ROS1`. I will expand the convergence to `ROS2` builds.