### PR TITLE
Fix dashing build break.

### DIFF
--- a/ros-colcon-build/dashing/build.rosinstall
+++ b/ros-colcon-build/dashing/build.rosinstall
@@ -9,4 +9,4 @@
 - git:
     local-name: rviz
     uri: https://github.com/ms-iot/rviz.git
-    version: ros2_patch
+    version: dashing_patch


### PR DESCRIPTION
The `ros2` branch for `rviz` is no longer commonly shared for `dashing` and `eloquent`, so I made a branch plus a patch to rescue the `dashing` build.