### PR TITLE
[catkin][melodic] Fixed build break

### DIFF
--- a/ros-catkin-build/melodic/build.rosinstall
+++ b/ros-catkin-build/melodic/build.rosinstall
@@ -10,3 +10,7 @@
     local-name: msft_ros_pkgs
     uri: https://github.com/ms-iot/msft_ros_pkgs
     version: master
+- git:
+    local-name: catkin
+    uri: https://github.com/ros/catkin.git
+    version: 0.7.19


### PR DESCRIPTION
Use the last stable released `catkin`. The latest code on the upstream seems to come with problems and I am confirming with the package owner.