### PR TITLE
[colcon][eloquent] skip ecl_type_traits before Windows enablement.

### DIFF
--- a/ros-colcon-build/eloquent/azure-pipelines.yml
+++ b/ros-colcon-build/eloquent/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
   strategy:
     matrix:
       eloquent-ALL:
-        ROSWIN_PACKAGE_SKIP: 'gazebo_ros theora_image_transport cartographer ros_workspace camera_info_manager teleop_twist_joy'
+        ROSWIN_PACKAGE_SKIP: 'gazebo_ros theora_image_transport cartographer ros_workspace camera_info_manager teleop_twist_joy ecl_type_traits'
   steps:
   # - template: ..\common\agent-clean.yml
   - template: ..\common\checkout.yml

--- a/ros-colcon-build/eloquent/build.rosinstall
+++ b/ros-colcon-build/eloquent/build.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: rviz
-    uri: https://github.com/ms-iot/rviz.git
-    version: ros2_patch


### PR DESCRIPTION
* skip `ecl_type_traits` before Windows enablement.
* remove `rviz` since now the patch is merged back on the upstream.