### PR TITLE
[catkin][melodic] use the upstream catkin.

### DIFF
--- a/ros-catkin-build/melodic/build.rosinstall
+++ b/ros-catkin-build/melodic/build.rosinstall
@@ -10,7 +10,3 @@
     local-name: msft_ros_pkgs
     uri: https://github.com/ms-iot/msft_ros_pkgs
     version: master
-- git:
-    local-name: catkin
-    uri: https://github.com/ros/catkin.git
-    version: 0.7.19


### PR DESCRIPTION
Switch back to use the upstream catkin since a recent regression is fixed. https://github.com/ros/catkin/pull/1041