### PR TITLE
Add ROS_PYTHON_VERSION for installation.

### DIFF
--- a/package-build/build.bat
+++ b/package-build/build.bat
@@ -3,6 +3,7 @@
 echo set "ROS_DISTRO=%ROS_DISTRO%" >> tools\setup.bat
 echo set "ROS_ETC_DIR=%ROS_ETC_DIR%" >> tools\setup.bat
 echo set "PYTHONHOME=%PYTHON_LOCATION%" >> tools\setup.bat
+echo set "ROS_PYTHON_VERSION=%ROS_PYTHON_VERSION%" >> tools\setup.bat
 
 :: create Chocolatey packages.
 copy template.nuspec ros-%ROS_DISTRO%-%ROSWIN_METAPACKAGE%.nuspec


### PR DESCRIPTION
`ROS_PYTHON_VERSION` is a environment variable, which is defined in [REP-149](https://www.ros.org/reps/rep-0149.html), to bootstrap the ROS tools (for example, `rosdep`) to use the correct conditional dependencies for the installation.

We already use it in the build pipeline. And we should also prime it for packaging, so the install script can inference the correct dependencies (see [examples](https://github.com/ros/ros_comm/blob/melodic-devel/tools/rosmaster/package.xml)) during installation. This pull request is to add the missing piece.