### PR TITLE
[melodic] lock ros_control to the LKG revision.

### DIFF
--- a/ros-catkin-build/melodic/build.rosinstall
+++ b/ros-catkin-build/melodic/build.rosinstall
@@ -18,3 +18,7 @@
     local-name: imu_tools
     uri: https://github.com/ccny-ros-pkg/imu_tools
     version: melodic
+- git:
+    local-name: ros_control
+    uri: https://github.com/ros-controls/ros_control.git
+    version: db8488110ee4dad908f855c0d61998e96f4447e7

--- a/ros-colcon-build/melodic/build.rosinstall
+++ b/ros-colcon-build/melodic/build.rosinstall
@@ -2,3 +2,7 @@
     local-name: geometry2
     uri: https://github.com/ms-iot/geometry2.git
     version: init_windows_msbuild_fix
+- git:
+    local-name: ros_control
+    uri: https://github.com/ros-controls/ros_control.git
+    version: db8488110ee4dad908f855c0d61998e96f4447e7


### PR DESCRIPTION
The [`ros_control`](https://github.com/ros-controls/ros_control) recently has a [change](https://github.com/ros-controls/ros_control/commit/10ff185bc31113ca434e3169e0e3b66193f4eef8) which could lead to a namespace conflicts with `ERROR` defined from `Windows` header. I locked the `ros_control` to the LKG revision before a solution is concluded.