### PR TITLE
remove filter override.

### DIFF
--- a/ros-catkin-build/melodic/runtests.rosinstall
+++ b/ros-catkin-build/melodic/runtests.rosinstall
@@ -1,8 +1,4 @@
 - git:
-    local-name: filters
-    uri: https://github.com/ms-iot/filters.git
-    version: init_windows
-- git:
     local-name: diagnostics
     uri: https://github.com/ms-iot/diagnostics.git
     version: init_windows


### PR DESCRIPTION
The pending PR of `filter` is merged by the upstream.