### PR TITLE
[melodic] remove ros_comm override.

### DIFF
--- a/ros-catkin-build/melodic/build.rosinstall
+++ b/ros-catkin-build/melodic/build.rosinstall
@@ -26,7 +26,3 @@
     local-name: gazebo_ros_pkgs
     uri: https://github.com/ms-iot/gazebo_ros_pkgs.git
     version: melodic-devel_patch
-- git:
-    local-name: ros_comm
-    uri: https://github.com/ms-iot/ros_comm.git
-    version: xmlrpc_slow_patch


### PR DESCRIPTION
The change is merged by the upstream, so we remove the override.