### PR TITLE
[common] remove geometry2 override.

### DIFF
--- a/ros-colcon-build/melodic/build.rosinstall
+++ b/ros-colcon-build/melodic/build.rosinstall
@@ -1,8 +1,4 @@
 - git:
-    local-name: geometry2
-    uri: https://github.com/ms-iot/geometry2.git
-    version: init_windows_msbuild_fix
-- git:
     local-name: ros_control
     uri: https://github.com/ros-controls/ros_control.git
     version: 4179515f2b5dc6b27d36c8788aa7a94813ebbd4a

--- a/ros-colcon-build/noetic/build.rosinstall
+++ b/ros-colcon-build/noetic/build.rosinstall
@@ -76,8 +76,8 @@
     version: init_windows
 - git:
     local-name: geometry2
-    uri: https://github.com/ms-iot/geometry2.git
-    version: init_windows
+    uri: https://github.com/ros/geometry2.git
+    version: melodic-devel
 - git:
     local-name: gl_dependency
     uri: https://github.com/ros-visualization/gl_dependency.git


### PR DESCRIPTION
The fix is merged by the upstream.