### PR TITLE
[common] unset Boost_ROOT

### DIFF
--- a/ros-catkin-build/setup.bat
+++ b/ros-catkin-build/setup.bat
@@ -2,3 +2,4 @@
 set PYTHONHOME=C:\opt\python27amd64\
 set PATH=C:\opt\python27amd64\;C:\opt\python27amd64\Scripts;%PATH%
 set PYTHONPATH=
+set Boost_ROOT=

--- a/ros-colcon-build/setup.bat
+++ b/ros-colcon-build/setup.bat
@@ -6,3 +6,4 @@ set PATH=C:\opt\python37amd64\Scripts;%PATH%
 set PATH=C:\opt\python37amd64;%PATH%
 set "PATH=C:\Program Files\Cppcheck;%PATH%"
 set PYTHONPATH=
+set Boost_ROOT=


### PR DESCRIPTION
Unsetting `%Boost_ROOT%` to prevent from picking the wrong `Boost` on the build agent.