### PR TITLE
[common] Unset Boost global override on hosted agent.

### DIFF
--- a/ros-catkin-build/setup.bat
+++ b/ros-catkin-build/setup.bat
@@ -7,6 +7,7 @@ set PYTHONPATH=
 set Boost_ROOT=
 set BOOST_ROOT_1_69_0=
 set BOOST_ROOT_1_72_0=
+set PATH=%PATH:C:\hostedtoolcache\windows\Boost\1.72.0;=%
 
 :: echo all environment variables
 set

--- a/ros-catkin-build/setup.bat
+++ b/ros-catkin-build/setup.bat
@@ -2,5 +2,8 @@
 set PYTHONHOME=C:\opt\python27amd64\
 set PATH=C:\opt\python27amd64\;C:\opt\python27amd64\Scripts;%PATH%
 set PYTHONPATH=
+
+:: unset Boost override
 set Boost_ROOT=
-set
+set BOOST_ROOT_1_69_0=
+set BOOST_ROOT_1_72_0=

--- a/ros-catkin-build/setup.bat
+++ b/ros-catkin-build/setup.bat
@@ -7,3 +7,6 @@ set PYTHONPATH=
 set Boost_ROOT=
 set BOOST_ROOT_1_69_0=
 set BOOST_ROOT_1_72_0=
+
+:: echo all environment variables
+set

--- a/ros-catkin-build/setup.bat
+++ b/ros-catkin-build/setup.bat
@@ -3,3 +3,4 @@ set PYTHONHOME=C:\opt\python27amd64\
 set PATH=C:\opt\python27amd64\;C:\opt\python27amd64\Scripts;%PATH%
 set PYTHONPATH=
 set Boost_ROOT=
+set

--- a/ros-colcon-build/setup.bat
+++ b/ros-colcon-build/setup.bat
@@ -11,6 +11,7 @@ set PYTHONPATH=
 set Boost_ROOT=
 set BOOST_ROOT_1_69_0=
 set BOOST_ROOT_1_72_0=
+set PATH=%PATH:C:\hostedtoolcache\windows\Boost\1.72.0;=%
 
 :: echo all environment variables
 set

--- a/ros-colcon-build/setup.bat
+++ b/ros-colcon-build/setup.bat
@@ -11,3 +11,6 @@ set PYTHONPATH=
 set Boost_ROOT=
 set BOOST_ROOT_1_69_0=
 set BOOST_ROOT_1_72_0=
+
+:: echo all environment variables
+set

--- a/ros-colcon-build/setup.bat
+++ b/ros-colcon-build/setup.bat
@@ -6,4 +6,8 @@ set PATH=C:\opt\python37amd64\Scripts;%PATH%
 set PATH=C:\opt\python37amd64;%PATH%
 set "PATH=C:\Program Files\Cppcheck;%PATH%"
 set PYTHONPATH=
+
+:: unset Boost override
 set Boost_ROOT=
+set BOOST_ROOT_1_69_0=
+set BOOST_ROOT_1_72_0=


### PR DESCRIPTION
More fixes to unset the Boost global override to make the build pick up the correct Boost.