### PR TITLE
[melodic] switch to use upstream rosdistro

### DIFF
--- a/ros-catkin-build/azure-pipelines.yml
+++ b/ros-catkin-build/azure-pipelines.yml
@@ -18,29 +18,30 @@ jobs:
         ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
       melodic-robot:
         ROSWIN_METAPACKAGE: 'robot'
-        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs navigation'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
       melodic-perception:
         ROSWIN_METAPACKAGE: 'perception'
-        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs diagnostic_updater'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
       melodic-navigation:
         ROSWIN_METAPACKAGE: 'navigation'
-        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs diagnostic_updater'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
       melodic-viz:
         ROSWIN_METAPACKAGE: 'viz'
-        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs roslint'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
       melodic-simulators:
         ROSWIN_METAPACKAGE: 'simulators'
         ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
       melodic-desktop:
         ROSWIN_METAPACKAGE: 'desktop'
-        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs rosserial joystick_drivers teleop_twist_joy navigation soem robotiq_2f_gripper_action_server robotiq_modbus_rtu image_transport_plugins imu_tools'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
       melodic-desktop_full:
         ROSWIN_METAPACKAGE: 'desktop_full'
-        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs rosserial joystick_drivers teleop_twist_joy navigation soem robotiq_2f_gripper_action_server robotiq_modbus_rtu ros_controllers imu_tools'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
         skipComponentGovernanceDetection: false
       melodic-moveit:
         ROSWIN_METAPACKAGE: 'moveit'
-        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs moveit_resources moveit_visual_tools perception desktop ros_control industrial_core descartes'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs moveit_resources moveit_tutorials moveit_visual_tools pcl_ros'
+        ROSWIN_ARGS_ROSINSTALL_GEN: '--exclude octomap'
       melodic-cartographer_ros:
         ROSWIN_METAPACKAGE: 'cartographer_ros'
         ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs cartographer_rviz'
@@ -52,9 +53,9 @@ jobs:
     ROS_DISTRO: 'melodic'
     ROS_SHARE_DIR: 'c:\opt\ros\melodic\x64\share'
     ROS_ETC_DIR: 'c:\opt\ros\melodic\x64\etc\ros'
-    ROSDISTRO_INDEX_URL: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/index.yaml'
     ROSWIN_ROSDEP_LIST_URI: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/rosdep/sources.list.d/10-ms-iot.list'
     ROSWIN_VSTOOL: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
+    ROSWIN_PACKAGE_SKIP: 'stage stage_ros'
     BUILD_TOOL_PACKAGE: 'ros-catkin-tools'
     BUILD_TOOL_PACKAGE_VERSION: '0.0.1.1903221831'
     PYTHON_LOCATION: 'c:\opt\python27amd64'

--- a/ros-catkin-build/azure-pipelines.yml
+++ b/ros-catkin-build/azure-pipelines.yml
@@ -33,10 +33,10 @@ jobs:
         ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
       melodic-desktop:
         ROSWIN_METAPACKAGE: 'desktop'
-        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs rosserial joystick_drivers teleop_twist_joy navigation soem robotiq_2f_gripper_action_server robotiq_modbus_rtu image_transport_plugins imu_tools'
       melodic-desktop_full:
         ROSWIN_METAPACKAGE: 'desktop_full'
-        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs rosserial joystick_drivers teleop_twist_joy navigation soem robotiq_2f_gripper_action_server robotiq_modbus_rtu ros_controllers imu_tools'
         skipComponentGovernanceDetection: false
       melodic-moveit:
         ROSWIN_METAPACKAGE: 'moveit'

--- a/ros-catkin-build/build.bat
+++ b/ros-catkin-build/build.bat
@@ -1,4 +1,9 @@
 @echo off
+set "ROSWIN_CATKIN_PACKAGE_SKIP=--ignore-pkg %ROSWIN_PACKAGE_SKIP%"
+if "%ROSWIN_PACKAGE_SKIP%"=="" (
+    set ROSWIN_CATKIN_PACKAGE_SKIP=
+)
+
 set BUILD_MERGED_ROS_PACKAGES=%ROSWIN_METAPACKAGE% %ROSWIN_ADDITIONAL_PACKAGE%
 pushd c:\catkin_ws
 copy src\catkin\bin\catkin_make_isolated src\catkin\bin\catkin_make_isolated.py
@@ -7,6 +12,7 @@ python src\catkin\bin\catkin_make_isolated.py ^
     --use-nmake ^
     --install ^
     --only-pkg-with-deps %BUILD_MERGED_ROS_PACKAGES% ^
+    %ROSWIN_CATKIN_PACKAGE_SKIP% ^
     -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
     -DCMAKE_PREFIX_PATH="%ROSWIN_CMAKE_PREFIX_PATH%" ^
     -DCMAKE_VERBOSE_MAKEFILE=ON ^

--- a/ros-catkin-build/build_test.bat
+++ b/ros-catkin-build/build_test.bat
@@ -1,4 +1,9 @@
 @echo off
+set "ROSWIN_CATKIN_PACKAGE_SKIP=--ignore-pkg %ROSWIN_PACKAGE_SKIP%"
+if "%ROSWIN_PACKAGE_SKIP%"=="" (
+    set ROSWIN_CATKIN_PACKAGE_SKIP=
+)
+
 set BUILD_MERGED_ROS_PACKAGES=%ROSWIN_METAPACKAGE% %ROSWIN_ADDITIONAL_PACKAGE%
 pushd c:\catkin_ws
 copy src\catkin\bin\catkin_make_isolated src\catkin\bin\catkin_make_isolated.py
@@ -7,6 +12,7 @@ python src\catkin\bin\catkin_make_isolated.py ^
     --use-nmake ^
     --install ^
     --only-pkg-with-deps %BUILD_MERGED_ROS_PACKAGES% ^
+    %ROSWIN_CATKIN_PACKAGE_SKIP% ^
     -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
     -DCMAKE_PREFIX_PATH="%ROSWIN_CMAKE_PREFIX_PATH%" ^
     -DCMAKE_VERBOSE_MAKEFILE=ON ^
@@ -20,6 +26,7 @@ python src\catkin\bin\catkin_make_isolated.py ^
     --use-nmake ^
     --install ^
     --only-pkg-with-deps %BUILD_MERGED_ROS_PACKAGES% ^
+    %ROSWIN_CATKIN_PACKAGE_SKIP% ^
     -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
     -DCMAKE_PREFIX_PATH="%ROSWIN_CMAKE_PREFIX_PATH%" ^
     -DCMAKE_VERBOSE_MAKEFILE=ON ^

--- a/ros-catkin-build/common/checkout.yml
+++ b/ros-catkin-build/common/checkout.yml
@@ -10,7 +10,7 @@ steps:
     call "setup.bat"
     md c:\catkin_ws\src
     pushd c:\catkin_ws
-    rosinstall_generator %ROSWIN_METAPACKAGE% %ROSWIN_ADDITIONAL_PACKAGE% --rosdistro %ROS_DISTRO% --deps --upstream-development > build.rosinstall
+    rosinstall_generator %ROSWIN_METAPACKAGE% %ROSWIN_ADDITIONAL_PACKAGE% --rosdistro %ROS_DISTRO% --deps --upstream-development %ROSWIN_ARGS_ROSINSTALL_GEN% > build.rosinstall
     type build.rosinstall
     wstool init src
     wstool merge -r -y -t src build.rosinstall

--- a/ros-catkin-build/melodic/build.rosinstall
+++ b/ros-catkin-build/melodic/build.rosinstall
@@ -1,3 +1,60 @@
+# override by ms-iot
+- git:
+    local-name: gencpp
+    uri: https://github.com/ms-iot/gencpp.git
+    version: windows
+- git:
+    local-name: abseil-cpp
+    uri: https://github.com/ms-iot/abseil-cpp.git
+    version: init_windows
+- git:
+    local-name: geometry
+    uri: https://github.com/ms-iot/geometry.git
+    version: init_windows
+- git:
+    local-name: geometry2
+    uri: https://github.com/ms-iot/geometry2.git
+    version: init_windows
+- git:
+    local-name: image_common
+    uri: https://github.com/ms-iot/image_common.git
+    version: init_windows
+- git:
+    local-name: industrial_core
+    uri: https://github.com/ms-iot/industrial_core.git
+    version: init_windows
+- git:
+    local-name: interactive_markers
+    uri: https://github.com/ms-iot/interactive_markers.git
+    version: init_windows
+- git:
+    local-name: joystick_drivers
+    uri: https://github.com/ms-iot/joystick_drivers.git
+    version: init_windows
+- git:
+    local-name: moveit
+    uri: https://github.com/ms-iot/moveit.git
+    version: windows_fix_melodic
+- git:
+    local-name: navigation
+    uri: https://github.com/ms-iot/navigation.git
+    version: init_windows
+- git:
+    local-name: pluginlib
+    uri: https://github.com/ms-iot/pluginlib.git
+    version: init_windows
+- git:
+    local-name: ros_tutorials
+    uri: https://github.com/ms-iot/ros_tutorials.git
+    version: init_windows
+- git:
+    local-name: rosserial
+    uri: https://github.com/ms-iot/rosserial.git
+    version: init_windows
+- git:
+    local-name: vision_opencv
+    uri: https://github.com/ms-iot/vision_opencv.git
+    version: init_windows
 - git:
     local-name: robotiq
     uri: https://github.com/ms-iot/robotiq
@@ -11,26 +68,39 @@
     uri: https://github.com/ms-iot/msft_ros_pkgs
     version: master
 - git:
-    local-name: eigenpy
-    uri: https://github.com/stack-of-tasks/eigenpy.git
-    version: v1.6.6
-- git:
-    local-name: imu_tools
-    uri: https://github.com/ccny-ros-pkg/imu_tools
-    version: melodic
-- git:
-    local-name: ros_control
-    uri: https://github.com/ros-controls/ros_control.git
-    version: 4179515f2b5dc6b27d36c8788aa7a94813ebbd4a
-- git:
     local-name: gazebo_ros_pkgs
     uri: https://github.com/ms-iot/gazebo_ros_pkgs.git
     version: melodic-devel_patch
 - git:
-    local-name: geometry2
-    uri: https://github.com/ms-iot/geometry2.git
+    local-name: diagnostics
+    uri: https://github.com/ms-iot/diagnostics.git
     version: init_windows
 - git:
-    local-name: gencpp
-    uri: https://github.com/ms-iot/gencpp.git
-    version: windows
+    local-name: urdf
+    uri: https://github.com/ms-iot/urdf.git
+    version: init_windows
+
+# override to workaround build issues
+- git:
+    local-name: eigenpy
+    uri: https://github.com/stack-of-tasks/eigenpy.git
+    version: v1.6.6
+- git:
+    local-name: ros_control
+    uri: https://github.com/ros-controls/ros_control.git
+    version: 4179515f2b5dc6b27d36c8788aa7a94813ebbd4a
+
+# additional packages not yet managed in rosdistro
+- git:
+    local-name: moveit_tutorials
+    uri: https://github.com/ros-planning/moveit_tutorials.git
+    version: melodic-devel
+- git:
+    local-name: cartographer_ros
+    uri: https://github.com/googlecartographer/cartographer_ros.git
+    version: master
+
+- git:
+    local-name: cartographer
+    uri: https://github.com/googlecartographer/cartographer.git
+    version: master

--- a/ros-catkin-build/melodic/runtests.rosinstall
+++ b/ros-catkin-build/melodic/runtests.rosinstall
@@ -1,8 +1,0 @@
-- git:
-    local-name: diagnostics
-    uri: https://github.com/ms-iot/diagnostics.git
-    version: init_windows
-- git:
-    local-name: urdf
-    uri: https://github.com/ms-iot/urdf.git
-    version: init_windows

--- a/ros-catkin-build/ros-melodic-desktop.runtests.yml
+++ b/ros-catkin-build/ros-melodic-desktop.runtests.yml
@@ -3,7 +3,7 @@ pr: none
 
 variables:
   ROSWIN_CATKIN_BUILD_WORKING_DIRECTORY: $(Build.SourcesDirectory)\ros-catkin-build
-  ROSWIN_ADDITIONAL_ROSINSTALL: runtests.rosinstall
+  ROSWIN_ADDITIONAL_ROSINSTALL: build.rosinstall
   ROSWIN_CMAKE_PREFIX_PATH: 'C:/opt/ros/melodic/x64;C:/opt/rosdeps/x64'
 
 jobs:
@@ -19,9 +19,9 @@ jobs:
     ROS_PYTHON_VERSION: '2'
     ROS_DISTRO: 'melodic'
     ROS_ETC_DIR: 'c:\opt\ros\melodic\x64\etc\ros'
-    ROSDISTRO_INDEX_URL: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/index.yaml'
     ROSWIN_ROSDEP_LIST_URI: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/rosdep/sources.list.d/10-ms-iot.list'
     ROSWIN_VSTOOL: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
+    ROSWIN_PACKAGE_SKIP: 'stage stage_ros'
   steps:
   - template: ..\common\agent-clean.yml
   - template: common\checkout.yml

--- a/ros-catkin-build/ros-melodic-desktop_full.runtests.yml
+++ b/ros-catkin-build/ros-melodic-desktop_full.runtests.yml
@@ -3,7 +3,7 @@ pr: none
 
 variables:
   ROSWIN_CATKIN_BUILD_WORKING_DIRECTORY: $(Build.SourcesDirectory)\ros-catkin-build
-  ROSWIN_ADDITIONAL_ROSINSTALL: runtests.rosinstall
+  ROSWIN_ADDITIONAL_ROSINSTALL: build.rosinstall
   ROSWIN_CMAKE_PREFIX_PATH: 'C:/opt/ros/melodic/x64;C:/opt/rosdeps/x64'
 
 jobs:
@@ -19,9 +19,9 @@ jobs:
     ROS_PYTHON_VERSION: '2'
     ROS_DISTRO: 'melodic'
     ROS_ETC_DIR: 'c:\opt\ros\melodic\x64\etc\ros'
-    ROSDISTRO_INDEX_URL: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/index.yaml'
     ROSWIN_ROSDEP_LIST_URI: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/rosdep/sources.list.d/10-ms-iot.list'
     ROSWIN_VSTOOL: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
+    ROSWIN_PACKAGE_SKIP: 'stage stage_ros'
   steps:
   - template: ..\common\agent-clean.yml
   - template: common\checkout.yml

--- a/ros-catkin-build/ros-melodic-ros_base.runtests.yml
+++ b/ros-catkin-build/ros-melodic-ros_base.runtests.yml
@@ -3,7 +3,7 @@ pr: none
 
 variables:
   ROSWIN_CATKIN_BUILD_WORKING_DIRECTORY: $(Build.SourcesDirectory)\ros-catkin-build
-  ROSWIN_ADDITIONAL_ROSINSTALL: runtests.rosinstall
+  ROSWIN_ADDITIONAL_ROSINSTALL: build.rosinstall
   ROSWIN_CMAKE_PREFIX_PATH: 'C:/opt/ros/melodic/x64;C:/opt/rosdeps/x64'
 
 jobs:
@@ -19,9 +19,9 @@ jobs:
     ROS_PYTHON_VERSION: '2'
     ROS_DISTRO: 'melodic'
     ROS_ETC_DIR: 'c:\opt\ros\melodic\x64\etc\ros'
-    ROSDISTRO_INDEX_URL: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/index.yaml'
     ROSWIN_ROSDEP_LIST_URI: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/rosdep/sources.list.d/10-ms-iot.list'
     ROSWIN_VSTOOL: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
+    ROSWIN_PACKAGE_SKIP: 'stage stage_ros'
   steps:
   - template: ..\common\agent-clean.yml
   - template: common\checkout.yml

--- a/ros-colcon-build/melodic/azure-pipelines.yml
+++ b/ros-colcon-build/melodic/azure-pipelines.yml
@@ -22,12 +22,10 @@ jobs:
     matrix:
       melodic-ros_base:
         ROSWIN_METAPACKAGE: 'ros_core'
-        ROSDISTRO_INDEX_URL: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/index.yaml'
         ROS_ETC_DIR: 'c:\opt\ros\melodic\x64\etc\ros'
         ROSWIN_CMAKE_INSTALL_PREFIX: 'c:/opt/ros/melodic/x64'
       melodic-desktop_full:
         ROSWIN_METAPACKAGE: 'desktop_full'
-        ROSDISTRO_INDEX_URL: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/index.yaml'
         ROS_ETC_DIR: 'c:\opt\ros\melodic\x64\etc\ros'
         ROSWIN_CMAKE_INSTALL_PREFIX: 'c:/opt/ros/melodic/x64'
   steps:


### PR DESCRIPTION
Since many of the repositories are merged by the upstream, I decided to switch `melodic` build to directly point to the upstream `rosdistro` and only override the repos required.

It means we don't need to process distribution file in [rosdistro-db](https://github.com/ms-iot/rosdistro-db/tree/init_windows) to keep it in sync, and the upstream one is the only source of truth.