### PR TITLE
[melodic] remove cartographer override.

### DIFF
--- a/ros-catkin-build/melodic/build.rosinstall
+++ b/ros-catkin-build/melodic/build.rosinstall
@@ -95,11 +95,3 @@
     local-name: moveit_tutorials
     uri: https://github.com/ros-planning/moveit_tutorials.git
     version: melodic-devel
-- git:
-    local-name: cartographer_ros
-    uri: https://github.com/googlecartographer/cartographer_ros.git
-    version: master
-- git:
-    local-name: cartographer
-    uri: https://github.com/googlecartographer/cartographer.git
-    version: master


### PR DESCRIPTION
The upstream source has been added to the upstream rosdistro, so we can remove the override here. (https://github.com/ros/rosdistro/pull/23819)