### PR TITLE
[foxy] skip ros_workspace to unblock the build breaks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For more information, visit https://aka.ms/ros.
 | ros-colon-build(noetic) | [![Build Status](https://ros-win.visualstudio.com/ros-win/_apis/build/status/ros-colcon-build%20(noetic)?branchName=master)](https://ros-win.visualstudio.com/ros-win/_build/latest?definitionId=75&branchName=master) |
 | ros-colon-build(dashing) | [![Build Status](https://ros-win.visualstudio.com/ros-win/_apis/build/status/ros-colcon-build%20(dashing)?branchName=master)](https://ros-win.visualstudio.com/ros-win/_build/latest?definitionId=61&branchName=master) |
 | ros-colon-build(eloquent) | [![Build Status](https://ros-win.visualstudio.com/ros-win/_apis/build/status/ros-colcon-build%20(eloquent)?branchName=master)](https://ros-win.visualstudio.com/ros-win/_build/latest?definitionId=74&branchName=master) |
+| ros-colon-build(foxy) | [![Build Status](https://ros-win.visualstudio.com/ros-win/_apis/build/status/ros-colcon-build%20(foxy)?branchName=master)](https://ros-win.visualstudio.com/ros-win/_build/latest?definitionId=80&branchName=master) |
 
 # Contributing
 

--- a/ros-colcon-build/foxy/azure-pipelines.yml
+++ b/ros-colcon-build/foxy/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
   strategy:
     matrix:
       foxy-ALL:
-        ROSWIN_PACKAGE_SKIP: ''
+        ROSWIN_PACKAGE_SKIP: 'ros_workspace'
   steps:
   - template: ..\..\common\agent-clean.yml
   - template: ..\common\checkout.yml


### PR DESCRIPTION
[`ros_workspace`](https://github.com/ros2/ros_workspace) is a package which is designed for Debian packaging experience, and which doesn't compile on Windows build. For now I skip this package to unblock the build break.