### PR TITLE
Revert "[melodic] remove cartographer override. (#67)"

### DIFF
--- a/ros-catkin-build/melodic/build.rosinstall
+++ b/ros-catkin-build/melodic/build.rosinstall
@@ -95,3 +95,11 @@
     local-name: moveit_tutorials
     uri: https://github.com/ros-planning/moveit_tutorials.git
     version: melodic-devel
+- git:
+    local-name: cartographer_ros
+    uri: https://github.com/googlecartographer/cartographer_ros.git
+    version: master
+- git:
+    local-name: cartographer
+    uri: https://github.com/googlecartographer/cartographer.git
+    version: master


### PR DESCRIPTION
This reverts commit 18db8913cbe7531f8a4b2ccb4be27e4c476ae1ae, in response to https://github.com/ros/rosdistro/pull/23827.