### PR TITLE
[melodic] remove rosserial override.

### DIFF
--- a/ros-catkin-build/melodic/build.rosinstall
+++ b/ros-catkin-build/melodic/build.rosinstall
@@ -36,10 +36,6 @@
     uri: https://github.com/ms-iot/pluginlib.git
     version: init_windows
 - git:
-    local-name: rosserial
-    uri: https://github.com/ms-iot/rosserial.git
-    version: init_windows
-- git:
     local-name: vision_opencv
     uri: https://github.com/ms-iot/vision_opencv.git
     version: init_windows


### PR DESCRIPTION
The patches are merged by the upstream, so we removed the `ms-iot` override.