### PR TITLE
Adding error handling for rosdep install step

### DIFF
--- a/package-build/tools/chocolateyInstall.ps1
+++ b/package-build/tools/chocolateyInstall.ps1
@@ -17,4 +17,8 @@ Get-ChocolateyUnzip @packageArgs
 Write-Host 'running rosdep...'
 $ErrorActionPreference = 'SilentlyContinue';
 $rosdepInstall = Join-Path $toolsDir 'rosdepInstall.bat'
-Start-Process -FilePath "$env:comspec" -Wait -NoNewWindow -ArgumentList "/c", $rosdepInstall
+$p = Start-Process -FilePath "$env:comspec" -Wait -NoNewWindow -ArgumentList "/c", $rosdepInstall
+If($p.Exitcode -ne 0)
+{
+  Throw "rosdepInstall.bat failed."
+}

--- a/package-build/tools/rosdepInstall.bat
+++ b/package-build/tools/rosdepInstall.bat
@@ -5,6 +5,27 @@ setlocal
 pushd %~dp0
 call "setup.bat"
 
+:: check all required environments are set
+if not defined ROS_DISTRO (
+    echo ROS_DISTRO should be defined. 1>&2
+    exit 1
+)
+
+if not defined ROS_ETC_DIR (
+    echo ROS_ETC_DIR should be defined. 1>&2
+    exit 1
+)
+
+if not defined PYTHONHOME (
+    echo PYTHONHOME should be defined. 1>&2
+    exit 1
+)
+
+if not defined ROS_PYTHON_VERSION (
+    echo ROS_PYTHON_VERSION should be defined. 1>&2
+    exit 1
+)
+
 :: use Python from ROS installation
 set PATH=%PYTHONHOME%;%PYTHONHOME%\Scripts;%PATH%
 set PYTHONPATH=
@@ -13,3 +34,4 @@ set PYTHONPATH=
 rosdep init
 rosdep update
 rosdep install --from-paths c:\opt\ros\%ROS_DISTRO%\x64\share --ignore-src -r -y
+if errorlevel 1 exit 1

--- a/ros-catkin-build/azure-pipelines.yml
+++ b/ros-catkin-build/azure-pipelines.yml
@@ -61,7 +61,7 @@ jobs:
     PYTHON_LOCATION: 'c:\opt\python27amd64'
     skipComponentGovernanceDetection: true
   steps:
-  - template: ..\common\agent-clean.yml
+  # - template: ..\common\agent-clean.yml
   - template: common\checkout.yml
   - template: common\build.yml
   - template: common\symbols.yml

--- a/ros-catkin-build/azure-pipelines.yml
+++ b/ros-catkin-build/azure-pipelines.yml
@@ -16,35 +16,35 @@ jobs:
       melodic-ros_base:
         ROSWIN_METAPACKAGE: 'ros_base'
         ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
-      melodic-robot:
-        ROSWIN_METAPACKAGE: 'robot'
-        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
-      melodic-perception:
-        ROSWIN_METAPACKAGE: 'perception'
-        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
-      melodic-navigation:
-        ROSWIN_METAPACKAGE: 'navigation'
-        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
-      melodic-viz:
-        ROSWIN_METAPACKAGE: 'viz'
-        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
-      melodic-simulators:
-        ROSWIN_METAPACKAGE: 'simulators'
-        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
-      melodic-desktop:
-        ROSWIN_METAPACKAGE: 'desktop'
-        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs rosserial joystick_drivers teleop_twist_joy navigation soem robotiq_2f_gripper_action_server robotiq_modbus_rtu image_transport_plugins imu_tools'
-      melodic-desktop_full:
-        ROSWIN_METAPACKAGE: 'desktop_full'
-        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs rosserial joystick_drivers teleop_twist_joy navigation soem robotiq_2f_gripper_action_server robotiq_modbus_rtu ros_controllers imu_tools'
-        skipComponentGovernanceDetection: false
-      melodic-moveit:
-        ROSWIN_METAPACKAGE: 'moveit'
-        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs moveit_resources moveit_tutorials moveit_visual_tools pcl_ros'
-        ROSWIN_ARGS_ROSINSTALL_GEN: '--exclude octomap'
-      melodic-cartographer_ros:
-        ROSWIN_METAPACKAGE: 'cartographer_ros'
-        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs cartographer_rviz'
+      # melodic-robot:
+      #   ROSWIN_METAPACKAGE: 'robot'
+      #   ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
+      # melodic-perception:
+      #   ROSWIN_METAPACKAGE: 'perception'
+      #   ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
+      # melodic-navigation:
+      #   ROSWIN_METAPACKAGE: 'navigation'
+      #   ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
+      # melodic-viz:
+      #   ROSWIN_METAPACKAGE: 'viz'
+      #   ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
+      # melodic-simulators:
+      #   ROSWIN_METAPACKAGE: 'simulators'
+      #   ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
+      # melodic-desktop:
+      #   ROSWIN_METAPACKAGE: 'desktop'
+      #   ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs rosserial joystick_drivers teleop_twist_joy navigation soem robotiq_2f_gripper_action_server robotiq_modbus_rtu image_transport_plugins imu_tools'
+      # melodic-desktop_full:
+      #   ROSWIN_METAPACKAGE: 'desktop_full'
+      #   ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs rosserial joystick_drivers teleop_twist_joy navigation soem robotiq_2f_gripper_action_server robotiq_modbus_rtu ros_controllers imu_tools'
+      #   skipComponentGovernanceDetection: false
+      # melodic-moveit:
+      #   ROSWIN_METAPACKAGE: 'moveit'
+      #   ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs moveit_resources moveit_tutorials moveit_visual_tools pcl_ros'
+      #   ROSWIN_ARGS_ROSINSTALL_GEN: '--exclude octomap'
+      # melodic-cartographer_ros:
+      #   ROSWIN_METAPACKAGE: 'cartographer_ros'
+      #   ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs cartographer_rviz'
   timeoutInMinutes: 300
   pool:
     vmImage: 'windows-2019'

--- a/ros-catkin-build/azure-pipelines.yml
+++ b/ros-catkin-build/azure-pipelines.yml
@@ -16,35 +16,35 @@ jobs:
       melodic-ros_base:
         ROSWIN_METAPACKAGE: 'ros_base'
         ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
-      # melodic-robot:
-      #   ROSWIN_METAPACKAGE: 'robot'
-      #   ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
-      # melodic-perception:
-      #   ROSWIN_METAPACKAGE: 'perception'
-      #   ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
-      # melodic-navigation:
-      #   ROSWIN_METAPACKAGE: 'navigation'
-      #   ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
-      # melodic-viz:
-      #   ROSWIN_METAPACKAGE: 'viz'
-      #   ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
-      # melodic-simulators:
-      #   ROSWIN_METAPACKAGE: 'simulators'
-      #   ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
-      # melodic-desktop:
-      #   ROSWIN_METAPACKAGE: 'desktop'
-      #   ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs rosserial joystick_drivers teleop_twist_joy navigation soem robotiq_2f_gripper_action_server robotiq_modbus_rtu image_transport_plugins imu_tools'
-      # melodic-desktop_full:
-      #   ROSWIN_METAPACKAGE: 'desktop_full'
-      #   ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs rosserial joystick_drivers teleop_twist_joy navigation soem robotiq_2f_gripper_action_server robotiq_modbus_rtu ros_controllers imu_tools'
-      #   skipComponentGovernanceDetection: false
-      # melodic-moveit:
-      #   ROSWIN_METAPACKAGE: 'moveit'
-      #   ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs moveit_resources moveit_tutorials moveit_visual_tools pcl_ros'
-      #   ROSWIN_ARGS_ROSINSTALL_GEN: '--exclude octomap'
-      # melodic-cartographer_ros:
-      #   ROSWIN_METAPACKAGE: 'cartographer_ros'
-      #   ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs cartographer_rviz'
+      melodic-robot:
+        ROSWIN_METAPACKAGE: 'robot'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
+      melodic-perception:
+        ROSWIN_METAPACKAGE: 'perception'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
+      melodic-navigation:
+        ROSWIN_METAPACKAGE: 'navigation'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
+      melodic-viz:
+        ROSWIN_METAPACKAGE: 'viz'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
+      melodic-simulators:
+        ROSWIN_METAPACKAGE: 'simulators'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs'
+      melodic-desktop:
+        ROSWIN_METAPACKAGE: 'desktop'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs rosserial joystick_drivers teleop_twist_joy navigation soem robotiq_2f_gripper_action_server robotiq_modbus_rtu image_transport_plugins imu_tools'
+      melodic-desktop_full:
+        ROSWIN_METAPACKAGE: 'desktop_full'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs rosserial joystick_drivers teleop_twist_joy navigation soem robotiq_2f_gripper_action_server robotiq_modbus_rtu ros_controllers imu_tools'
+        skipComponentGovernanceDetection: false
+      melodic-moveit:
+        ROSWIN_METAPACKAGE: 'moveit'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs moveit_resources moveit_tutorials moveit_visual_tools pcl_ros'
+        ROSWIN_ARGS_ROSINSTALL_GEN: '--exclude octomap'
+      melodic-cartographer_ros:
+        ROSWIN_METAPACKAGE: 'cartographer_ros'
+        ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros_pkgs cartographer_rviz'
   timeoutInMinutes: 300
   pool:
     vmImage: 'windows-2019'
@@ -61,7 +61,7 @@ jobs:
     PYTHON_LOCATION: 'c:\opt\python27amd64'
     skipComponentGovernanceDetection: true
   steps:
-  # - template: ..\common\agent-clean.yml
+  - template: ..\common\agent-clean.yml
   - template: common\checkout.yml
   - template: common\build.yml
   - template: common\symbols.yml
@@ -71,9 +71,9 @@ jobs:
   dependsOn: Build
   strategy:
     matrix:
-      melodic-ros_core:
+      melodic-desktop_full:
         ROS_DISTRO: 'melodic'
-        ROSWIN_METAPACKAGE: 'ros_core'
+        ROSWIN_METAPACKAGE: 'desktop_full'
   timeoutInMinutes: 300
   pool:
     vmImage: 'windows-2019'

--- a/ros-colcon-build/crystal/azure-pipelines.yml
+++ b/ros-colcon-build/crystal/azure-pipelines.yml
@@ -39,9 +39,9 @@ jobs:
   dependsOn: Build
   strategy:
     matrix:
-      crystal-ros_core:
+      crystal-desktop:
         ROS_DISTRO: 'crystal'
-        ROSWIN_METAPACKAGE: 'ros_core'
+        ROSWIN_METAPACKAGE: 'desktop'
   timeoutInMinutes: 300
   pool:
     vmImage: 'windows-2019'

--- a/ros-colcon-build/crystal/azure-pipelines.yml
+++ b/ros-colcon-build/crystal/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   variables:
-    ROSWIN_ROSDEP_LIST_URI: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows_py37/rosdep/sources.list.d/10-ms-iot.list'
+    ROSWIN_ROSDEP_LIST_URI: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/rosdep/sources.list.d/10-ms-iot.list'
     ROSWIN_METAPACKAGE: 'ALL'
     ROSWIN_ADDITIONAL_PACKAGE: 'ros_rosdeps'
     ROSWIN_VSTOOL: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat'

--- a/ros-colcon-build/dashing/azure-pipelines.yml
+++ b/ros-colcon-build/dashing/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   variables:
-    ROSWIN_ROSDEP_LIST_URI: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows_py37/rosdep/sources.list.d/10-ms-iot.list'
+    ROSWIN_ROSDEP_LIST_URI: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/rosdep/sources.list.d/10-ms-iot.list'
     ROSWIN_METAPACKAGE: 'ALL'
     ROSWIN_VSTOOL: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
     ROSWIN_CMAKE_INSTALL_PREFIX: 'c:/opt/ros/dashing/x64'

--- a/ros-colcon-build/dashing/azure-pipelines.yml
+++ b/ros-colcon-build/dashing/azure-pipelines.yml
@@ -29,8 +29,6 @@ jobs:
         ROSWIN_METAPACKAGE: 'ros_base'
       dashing-desktop:
         ROSWIN_METAPACKAGE: 'desktop'
-      # dashing-ALL:
-      #   ROSWIN_PACKAGE_SKIP: 'apriltag behaviortree_cpp_v3 cartographer gazebo_ros ros_workspace'
   steps:
   - template: ..\..\common\agent-clean.yml
   - template: ..\common\checkout.yml
@@ -41,9 +39,9 @@ jobs:
   dependsOn: Build
   strategy:
     matrix:
-      dashing-ros_core:
+      dashing-desktop:
         ROS_DISTRO: 'dashing'
-        ROSWIN_METAPACKAGE: 'ros_core'
+        ROSWIN_METAPACKAGE: 'desktop'
   timeoutInMinutes: 300
   pool:
     vmImage: 'windows-2019'

--- a/ros-colcon-build/eloquent/azure-pipelines.yml
+++ b/ros-colcon-build/eloquent/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   variables:
-    ROSWIN_ROSDEP_LIST_URI: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows_py37/rosdep/sources.list.d/10-ms-iot.list'
+    ROSWIN_ROSDEP_LIST_URI: 'https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/rosdep/sources.list.d/10-ms-iot.list'
     ROSWIN_METAPACKAGE: 'ALL'
     ROSWIN_VSTOOL: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
     ROSWIN_CMAKE_INSTALL_PREFIX: 'c:/opt/ros/eloquent/x64'

--- a/ros-colcon-build/eloquent/azure-pipelines.yml
+++ b/ros-colcon-build/eloquent/azure-pipelines.yml
@@ -29,8 +29,6 @@ jobs:
         ROSWIN_METAPACKAGE: 'ros_base'
       eloquent-desktop:
         ROSWIN_METAPACKAGE: 'desktop'
-      # eloquent-ALL:
-      #   ROSWIN_PACKAGE_SKIP: 'gazebo_ros theora_image_transport cartographer ros_workspace camera_info_manager teleop_twist_joy ecl_type_traits'
   steps:
   - template: ..\..\common\agent-clean.yml
   - template: ..\common\checkout.yml


### PR DESCRIPTION
* Adding the error check for `rosdep install`, so the failure can propagate to `Chocolatey`.
* Unify all rosdep database to use the same file for ROS1 and ROS2.
* Test the install to `desktop` (or `desktop_full`) variant if it exists.