### PR TITLE
[ros2] pinning cmake to the LKG version.

### DIFF
--- a/ros-colcon-build/crystal/rosdep.bat
+++ b/ros-colcon-build/crystal/rosdep.bat
@@ -1,2 +1,3 @@
 @echo off
 choco upgrade -y asio
+pip install --upgrade --force-reinstall cmake==3.16.3

--- a/ros-colcon-build/dashing/rosdep.bat
+++ b/ros-colcon-build/dashing/rosdep.bat
@@ -1,2 +1,3 @@
 @echo off
 choco upgrade -y asio
+pip install --upgrade --force-reinstall cmake==3.16.3

--- a/ros-colcon-build/eloquent/rosdep.bat
+++ b/ros-colcon-build/eloquent/rosdep.bat
@@ -1,2 +1,3 @@
 @echo off
 choco upgrade -y asio
+pip install --upgrade --force-reinstall cmake==3.16.3

--- a/ros-colcon-build/foxy/rosdep.bat
+++ b/ros-colcon-build/foxy/rosdep.bat
@@ -1,0 +1,2 @@
+@echo off
+pip install --upgrade --force-reinstall cmake==3.16.3


### PR DESCRIPTION
There are some [`Modules`](https://cmake.org/cmake/help/v3.17/release/3.17.html#modules) changes in CMake 3.17 breaking the ROS build, so pinning the cmake to the previous LKG version to unblock it.