### PR TITLE
[foxy] ignore librealsense2 for now.

### DIFF
--- a/ros-colcon-build/foxy/azure-pipelines.yml
+++ b/ros-colcon-build/foxy/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
   strategy:
     matrix:
       foxy-ALL:
-        ROSWIN_PACKAGE_SKIP: 'ros_workspace'
+        ROSWIN_PACKAGE_SKIP: 'ros_workspace librealsense2'
   steps:
   - template: ..\..\common\agent-clean.yml
   - template: ..\common\checkout.yml


### PR DESCRIPTION
`librealsense2` causes the build break on CI. Since it is not an essential package, I take it offline for now.