### PR TITLE
[melodic] override cmake_modules

### DIFF
--- a/ros-catkin-build/melodic/build.rosinstall
+++ b/ros-catkin-build/melodic/build.rosinstall
@@ -1,5 +1,9 @@
 # override by ms-iot (ROS 1 essential)
 - git:
+    local-name: cmake_modules
+    uri: https://github.com/ms-iot/cmake_modules.git
+    version: windows//0.4-devel
+- git:
     local-name: diagnostics
     uri: https://github.com/ms-iot/diagnostics.git
     version: init_windows


### PR DESCRIPTION
Trying to drop the full path of `rpcrt4.lib` being baked into the auto-generated CMake config files. For example, we don't want `C:/Program Files (x86)/Windows Kits/10/Lib/10.0.19041.0/um/x64/RpcRT4.Lib` baked in the `bondcpp-config.cmake` and we want the CMake config to be more resilient to Windows SDK versions.