### PR TITLE
[eloquent] remove fast-rtps pinning.

### DIFF
--- a/ros-colcon-build/eloquent/build.rosinstall
+++ b/ros-colcon-build/eloquent/build.rosinstall
@@ -1,9 +1,5 @@
 # override by ms-iot
 - git:
-    local-name: fastrtps
-    uri: https://github.com/eProsima/Fast-RTPS.git
-    version: 1.9.x
-- git:
     local-name: geometry2
     uri: https://github.com/ms-iot/geometry2-1.git
     version: eloquent-windows


### PR DESCRIPTION
removing the fast-rtps pinning and use the latest from the upstream.