### PR TITLE
[common] Adding CMAKE_PROGRAM_PATH to make protobuf compiler visible for build.

### DIFF
--- a/ros-catkin-build/azure-pipelines.yml
+++ b/ros-catkin-build/azure-pipelines.yml
@@ -5,6 +5,7 @@ variables:
   ROSWIN_CATKIN_BUILD_WORKING_DIRECTORY: $(Build.SourcesDirectory)\ros-catkin-build
   ROSWIN_ADDITIONAL_ROSINSTALL: build.rosinstall
   ROSWIN_CMAKE_PREFIX_PATH: 'C:/opt/ros/melodic/x64;C:/opt/rosdeps/x64;C:/vcpkg/installed/x64-windows'
+  ROSWIN_CMAKE_PROGRAM_PATH: 'C:\opt\rosdeps\x64\tools\protobuf'
 
 jobs:
 - job: Build

--- a/ros-catkin-build/build.bat
+++ b/ros-catkin-build/build.bat
@@ -16,6 +16,7 @@ python src\catkin\bin\catkin_make_isolated.py ^
     -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
     -DCMAKE_PREFIX_PATH="%ROSWIN_CMAKE_PREFIX_PATH%" ^
     -DCMAKE_VERBOSE_MAKEFILE=ON ^
+    -DCMAKE_PROGRAM_PATH="%ROSWIN_CMAKE_PROGRAM_PATH%" ^
     -DPYTHON_VERSION=2.7 ^
     -DPYTHON_EXECUTABLE=C:\opt\python27amd64\python.exe ^
     -DPYTHON_LIBRARIES=C:\opt\python27amd64\Libs ^

--- a/ros-catkin-build/build_test.bat
+++ b/ros-catkin-build/build_test.bat
@@ -16,6 +16,7 @@ python src\catkin\bin\catkin_make_isolated.py ^
     -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
     -DCMAKE_PREFIX_PATH="%ROSWIN_CMAKE_PREFIX_PATH%" ^
     -DCMAKE_VERBOSE_MAKEFILE=ON ^
+    -DCMAKE_PROGRAM_PATH="%ROSWIN_CMAKE_PROGRAM_PATH%" ^
     -DPYTHON_VERSION=2.7 ^
     -DPYTHON_EXECUTABLE=C:\opt\python27amd64\python.exe ^
     -DPYTHON_LIBRARIES=C:\opt\python27amd64\Libs
@@ -30,6 +31,7 @@ python src\catkin\bin\catkin_make_isolated.py ^
     -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
     -DCMAKE_PREFIX_PATH="%ROSWIN_CMAKE_PREFIX_PATH%" ^
     -DCMAKE_VERBOSE_MAKEFILE=ON ^
+    -DCMAKE_PROGRAM_PATH="%ROSWIN_CMAKE_PROGRAM_PATH%" ^
     -DPYTHON_VERSION=2.7 ^
     -DPYTHON_EXECUTABLE=C:\opt\python27amd64\python.exe ^
     -DPYTHON_LIBRARIES=C:\opt\python27amd64\Libs ^

--- a/ros-colcon-build/build.bat
+++ b/ros-colcon-build/build.bat
@@ -34,6 +34,7 @@ colcon --log-level info build ^
        --cmake-args ^
         -DCMAKE_BUILD_TYPE=Release ^
         -DCMAKE_VERBOSE_MAKEFILE=ON ^
+        -DCMAKE_PROGRAM_PATH="%ROSWIN_CMAKE_PROGRAM_PATH%" ^
         -DPYTHON_VERSION=3.7 ^
         -DPYTHON_EXECUTABLE=C:\opt\python37amd64\python.exe ^
         -DPYTHON_LIBRARIES=C:\opt\python37amd64\Libs

--- a/ros-colcon-build/crystal/azure-pipelines.yml
+++ b/ros-colcon-build/crystal/azure-pipelines.yml
@@ -15,6 +15,7 @@ jobs:
     ROSWIN_ADDITIONAL_PACKAGE: 'ros_rosdeps'
     ROSWIN_VSTOOL: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
     ROSWIN_CMAKE_INSTALL_PREFIX: 'c:/opt/ros/crystal/x64'
+    ROSWIN_CMAKE_PROGRAM_PATH: 'C:\opt\rosdeps\x64\tools\protobuf'
     BUILD_TOOL_PACKAGE: 'ros-colcon-tools'
     BUILD_TOOL_PACKAGE_VERSION: '0.0.1.1905240527'
     PYTHON_LOCATION: 'c:\opt\python37amd64'

--- a/ros-colcon-build/dashing/azure-pipelines.yml
+++ b/ros-colcon-build/dashing/azure-pipelines.yml
@@ -14,6 +14,7 @@ jobs:
     ROSWIN_METAPACKAGE: 'ALL'
     ROSWIN_VSTOOL: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
     ROSWIN_CMAKE_INSTALL_PREFIX: 'c:/opt/ros/dashing/x64'
+    ROSWIN_CMAKE_PROGRAM_PATH: 'C:\opt\rosdeps\x64\tools\protobuf'
     ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros2_env'
     ROSWIN_PACKAGE_SKIP: 'rttest tlsf tlsf_cpp pendulum_control'
     ROS_PYTHON_VERSION: '3'

--- a/ros-colcon-build/eloquent/azure-pipelines.yml
+++ b/ros-colcon-build/eloquent/azure-pipelines.yml
@@ -14,6 +14,7 @@ jobs:
     ROSWIN_METAPACKAGE: 'ALL'
     ROSWIN_VSTOOL: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
     ROSWIN_CMAKE_INSTALL_PREFIX: 'c:/opt/ros/eloquent/x64'
+    ROSWIN_CMAKE_PROGRAM_PATH: 'C:\opt\rosdeps\x64\tools\protobuf'
     ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros2_env'
     ROSWIN_PACKAGE_SKIP: 'rttest tlsf tlsf_cpp pendulum_control'
     ROS_PYTHON_VERSION: '3'

--- a/ros-colcon-build/foxy/azure-pipelines.yml
+++ b/ros-colcon-build/foxy/azure-pipelines.yml
@@ -14,6 +14,7 @@ jobs:
     ROSWIN_METAPACKAGE: 'ALL'
     ROSWIN_VSTOOL: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
     ROSWIN_CMAKE_INSTALL_PREFIX: 'c:/opt/ros/foxy/x64'
+    ROSWIN_CMAKE_PROGRAM_PATH: 'C:\opt\rosdeps\x64\tools\protobuf'
     ROSWIN_ADDITIONAL_PACKAGE: 'msft_ros2_env'
     ROSWIN_PACKAGE_SKIP: 'rttest tlsf tlsf_cpp pendulum_control'
     ROS_PYTHON_VERSION: '3'

--- a/ros-colcon-build/noetic/azure-pipelines.yml
+++ b/ros-colcon-build/noetic/azure-pipelines.yml
@@ -15,6 +15,8 @@ jobs:
     ROSWIN_VSTOOL: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
     ROSWIN_PACKAGE_SKIP: 'stage stage_ros'
     ROSWIN_ADDITIONAL_PACKAGE: 'msft_colcon_env'
+    ROSWIN_CMAKE_INSTALL_PREFIX: 'c:/opt/ros/noetic/x64'
+    ROSWIN_CMAKE_PROGRAM_PATH: 'C:\opt\rosdeps\x64\tools\protobuf'
     BUILD_TOOL_PACKAGE: 'ros-colcon-tools'
     BUILD_TOOL_PACKAGE_VERSION: '0.0.1.1905240527'
     PYTHON_LOCATION: 'c:\opt\python37amd64'
@@ -22,7 +24,6 @@ jobs:
     ROS_PYTHON_VERSION: '3'
     ROS_DISTRO: 'noetic'
     ROS_ETC_DIR: 'c:\opt\ros\noetic\x64\etc\ros'
-    ROSWIN_CMAKE_INSTALL_PREFIX: 'c:/opt/ros/noetic/x64'
   strategy:
     matrix:
       noetic-desktop_full:


### PR DESCRIPTION
For the Gazebo v9.13.1, it requires the CMake to give it hint where the protobuf compiler is from `CMAKE_PROGRAM_PATH`.