### PR TITLE
[ROS2] more fixes.

### DIFF
--- a/ros-colcon-build/common/checkout.yml
+++ b/ros-colcon-build/common/checkout.yml
@@ -10,7 +10,7 @@ steps:
 - script: |
     call "setup.bat"
     md c:\colcon_ws\src
-    rosinstall_generator %ROSWIN_METAPACKAGE% --rosdistro %ROS_DISTRO% --deps > build.rosinstall
+    rosinstall_generator %ROSWIN_METAPACKAGE% --rosdistro %ROS_DISTRO% --deps %ROSINSTALL_GENERATOR_EXTRA_ARGS% > build.rosinstall
     pushd c:\colcon_ws
     wstool init src
     wstool merge -r -y -t src %ROSWIN_COLCON_BUILD_WORKING_DIRECTORY%\build.rosinstall

--- a/ros-colcon-build/common/runtests.yml
+++ b/ros-colcon-build/common/runtests.yml
@@ -5,9 +5,11 @@ steps:
     call "test.bat"
   workingDirectory: $(ROSWIN_COLCON_BUILD_WORKING_DIRECTORY)
   displayName: 'Run tests for ROS workspace'
+  condition: and(succeeded(), eq(variables.ROSWIN_ENABLE_TESTING, true))
 - task: PublishTestResults@2
   displayName: Publish test results
   inputs:
     testRunner: 'jUnit'
     testResultsFiles: '**\*.xml'
     searchFolder: 'c:\colcon_ws\build'
+  condition: and(succeeded(), eq(variables.ROSWIN_ENABLE_TESTING, true))

--- a/ros-colcon-build/dashing/azure-pipelines.yml
+++ b/ros-colcon-build/dashing/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
     matrix:
       dashing-desktop:
         ROSWIN_METAPACKAGE: 'desktop'
-      dashing-rel:
+      dashing-ALL:
         ROSWIN_RELEASE_REPO: 'https://raw.githubusercontent.com/ros2/ros2/release-dashing-20200722/ros2.repos'
         ROSWIN_BUILDNUMBER: '20200722.0.0'
         ROSWIN_METAPACKAGE: 'ALL'
@@ -47,9 +47,9 @@ jobs:
       dashing-desktop:
         ROS_DISTRO: 'dashing'
         ROSWIN_METAPACKAGE: 'desktop'
-      dashing-rel:
+      dashing-ALL:
         ROS_DISTRO: 'dashing'
-        ROSWIN_METAPACKAGE: 'rel'
+        ROSWIN_METAPACKAGE: 'ALL'
   timeoutInMinutes: 360
   pool:
     vmImage: 'windows-2019'

--- a/ros-colcon-build/eloquent/azure-pipelines.yml
+++ b/ros-colcon-build/eloquent/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
     matrix:
       eloquent-desktop:
         ROSWIN_METAPACKAGE: 'desktop'
-      eloquent-rel:
+      eloquent-ALL:
         ROSWIN_RELEASE_REPO: 'https://raw.githubusercontent.com/ros2/ros2/release-eloquent-20201024-1/ros2.repos'
         ROSWIN_BUILDNUMBER: '20201024.1.0'
         ROSWIN_METAPACKAGE: 'ALL'
@@ -47,9 +47,9 @@ jobs:
       eloquent-desktop:
         ROS_DISTRO: 'eloquent'
         ROSWIN_METAPACKAGE: 'desktop'
-      eloquent-rel:
+      eloquent-ALL:
         ROS_DISTRO: 'eloquent'
-        ROSWIN_METAPACKAGE: 'rel'
+        ROSWIN_METAPACKAGE: 'ALL'
   timeoutInMinutes: 360
   pool:
     vmImage: 'windows-2019'

--- a/ros-colcon-build/foxy/azure-pipelines.yml
+++ b/ros-colcon-build/foxy/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
     matrix:
       foxy-desktop:
         ROSWIN_METAPACKAGE: 'desktop'
-      foxy-rel:
+      foxy-ALL:
         ROSWIN_RELEASE_REPO: 'https://raw.githubusercontent.com/ros2/ros2/release-foxy-20200710/ros2.repos'
         ROSWIN_BUILDNUMBER: '20200710.0.0'
         ROSWIN_METAPACKAGE: 'ALL'
@@ -47,9 +47,9 @@ jobs:
       foxy-desktop:
         ROS_DISTRO: 'foxy'
         ROSWIN_METAPACKAGE: 'desktop'
-      foxy-rel:
+      foxy-ALL:
         ROS_DISTRO: 'foxy'
-        ROSWIN_METAPACKAGE: 'rel'
+        ROSWIN_METAPACKAGE: 'ALL'
   timeoutInMinutes: 360
   pool:
     vmImage: 'windows-2019'

--- a/ros-colcon-build/noetic/azure-pipelines.yml
+++ b/ros-colcon-build/noetic/azure-pipelines.yml
@@ -25,6 +25,7 @@ jobs:
     ROS_PYTHON_VERSION: '3'
     ROS_DISTRO: 'noetic'
     ROS_ETC_DIR: 'c:\opt\ros\noetic\x64\etc\ros'
+    ROSINSTALL_GENERATOR_EXTRA_ARGS: '--upstream-development'
   strategy:
     matrix:
       noetic-desktop_full:


### PR DESCRIPTION
* Address the typo to cause build breaks.
* Conditionally control the testing runs.
* Address a regression to `noetic` build breaks when we still expect to use the upstream branch.