### PR TITLE
[Noetic] Fixing noetic build break.

### DIFF
--- a/ros-colcon-build/noetic/build.rosinstall
+++ b/ros-colcon-build/noetic/build.rosinstall
@@ -1,5 +1,9 @@
 # override by ms-iot
 - git:
+    local-name: pluginlib
+    uri: https://github.com/ms-iot/pluginlib.git
+    version: windows/1.13.0
+- git:
     local-name: geometry
     uri: https://github.com/ms-iot/geometry.git
     version: windows/noetic-devel
@@ -19,6 +23,13 @@
     local-name: gazebo_ros_pkgs
     uri: https://github.com/ms-iot/gazebo_ros_pkgs.git
     version: windows/noetic-devel
+
+# override for LKG
+
+- git:
+    local-name: diagnostics
+    uri: https://github.com/ros/diagnostics.git
+    version: 1.9.5
 
 # override by ms-iot (Windows Installation)
 - git:


### PR DESCRIPTION
* A recent change in the https://github.com/ros/diagnostics.git caused Windows side build break. Before figuring out the right way to resolve it, pin it back to the LKG.
* Patched the pluginlib to enable plugin loading.