### PR TITLE
[Melodic] Fix recent installation break

### DIFF
--- a/package-build/tools/rosdepInstall.bat
+++ b/package-build/tools/rosdepInstall.bat
@@ -35,6 +35,12 @@ if not defined VCPKG_ROOT (
 set PATH=%PYTHONHOME%;%PYTHONHOME%\Scripts;%VCPKG_ROOT%;%PATH%
 set PYTHONPATH=
 
+:: workaround opencv-python complication
+:: https://github.com/skvark/opencv-python/issues/369
+if "%ROS_DISTRO%"=="melodic" (
+    python -m pip install opencv-python==4.2.0.32
+)
+
 :: install ROS system dependencies
 rosdep init
 rosdep update

--- a/ros-catkin-build/melodic/build.rosinstall
+++ b/ros-catkin-build/melodic/build.rosinstall
@@ -16,10 +16,6 @@
     uri: https://github.com/ms-iot/geometry.git
     version: init_windows
 - git:
-    local-name: geometry2
-    uri: https://github.com/ms-iot/geometry2.git
-    version: init_windows
-- git:
     local-name: image_common
     uri: https://github.com/ms-iot/image_common.git
     version: init_windows


### PR DESCRIPTION
* Fixing the recent installation break caused by `opencv-python`.
* Removing the unused repo override.