### PR TITLE
[Common] Continue even when LKG install fails.

### DIFF
--- a/package-build/package-test-upgrade.yml
+++ b/package-build/package-test-upgrade.yml
@@ -16,6 +16,7 @@ steps:
 - script: |
     choco install ros-%ROS_DISTRO%-%ROSWIN_METAPACKAGE% -y
   displayName: Install Latest Released Chocolatey packages
+  continueOnError: 'true'
 - script: |
     choco upgrade ros-%ROS_DISTRO%-%ROSWIN_METAPACKAGE% -y --pre
   displayName: Upgrade to Pre-released Chocolatey packages


### PR DESCRIPTION
To accommodate the case where the current LKG install broken, this will continue to test the upgrade path but there will be a warning (!) on the pipeline result. And it leaves the final adjudication to the release developers.