### PR TITLE
[ROS2] update the release snapshots

### DIFF
--- a/ros-colcon-build/eloquent/azure-pipelines.yml
+++ b/ros-colcon-build/eloquent/azure-pipelines.yml
@@ -31,8 +31,8 @@ jobs:
       eloquent-desktop:
         ROSWIN_METAPACKAGE: 'desktop'
       eloquent-ALL:
-        ROSWIN_RELEASE_REPO: 'https://raw.githubusercontent.com/ros2/ros2/release-eloquent-20201024-1/ros2.repos'
-        ROSWIN_BUILDNUMBER: '20201024.1.0.${ROSWIN_DATE}'
+        ROSWIN_RELEASE_REPO: 'https://raw.githubusercontent.com/ros2/ros2/release-eloquent-20200124-1/ros2.repos'
+        ROSWIN_BUILDNUMBER: '20200124.1.0.${ROSWIN_DATE}'
         ROSWIN_METAPACKAGE: 'ALL'
         ROSWIN_PACKAGE_SKIP: 'rttest tlsf tlsf_cpp pendulum_control msft_colcon_env msft_ros_env msft_ros_pkgs msft_ros_vcpkg'
   steps:

--- a/ros-colcon-build/eloquent/azure-pipelines.yml
+++ b/ros-colcon-build/eloquent/azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
         ROSWIN_RELEASE_REPO: 'https://raw.githubusercontent.com/ros2/ros2/release-eloquent-20200124-1/ros2.repos'
         ROSWIN_BUILDNUMBER: '20200124.1.0.${ROSWIN_DATE}'
         ROSWIN_METAPACKAGE: 'ALL'
-        ROSWIN_PACKAGE_SKIP: 'osrf_testing_tools_cpp rttest tlsf tlsf_cpp pendulum_control msft_colcon_env msft_ros_env msft_ros_pkgs msft_ros_vcpkg'
+        ROSWIN_PACKAGE_SKIP: 'rttest tlsf tlsf_cpp pendulum_control msft_colcon_env msft_ros_env msft_ros_pkgs msft_ros_vcpkg'
   steps:
   - template: ..\..\common\agent-prep.yml
   - template: ..\common\checkout.yml

--- a/ros-colcon-build/eloquent/azure-pipelines.yml
+++ b/ros-colcon-build/eloquent/azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
         ROSWIN_RELEASE_REPO: 'https://raw.githubusercontent.com/ros2/ros2/release-eloquent-20200124-1/ros2.repos'
         ROSWIN_BUILDNUMBER: '20200124.1.0.${ROSWIN_DATE}'
         ROSWIN_METAPACKAGE: 'ALL'
-        ROSWIN_PACKAGE_SKIP: 'rttest tlsf tlsf_cpp pendulum_control msft_colcon_env msft_ros_env msft_ros_pkgs msft_ros_vcpkg'
+        ROSWIN_PACKAGE_SKIP: 'osrf_testing_tools_cpp rttest tlsf tlsf_cpp pendulum_control msft_colcon_env msft_ros_env msft_ros_pkgs msft_ros_vcpkg'
   steps:
   - template: ..\..\common\agent-prep.yml
   - template: ..\common\checkout.yml

--- a/ros-colcon-build/foxy/azure-pipelines.yml
+++ b/ros-colcon-build/foxy/azure-pipelines.yml
@@ -31,13 +31,11 @@ jobs:
       foxy-desktop:
         ROSWIN_METAPACKAGE: 'desktop'
       foxy-ALL:
-        ROSWIN_RELEASE_REPO: 'https://raw.githubusercontent.com/ros2/ros2/release-foxy-20200710/ros2.repos'
-        ROSWIN_BUILDNUMBER: '20200710.0.0.$(ROSWIN_DATE)'
+        ROSWIN_RELEASE_REPO: 'https://raw.githubusercontent.com/ros2/ros2/release-foxy-20200807/ros2.repos'
+        ROSWIN_BUILDNUMBER: '20200807.0.0.$(ROSWIN_DATE)'
         ROSWIN_METAPACKAGE: 'ALL'
         ROSWIN_PACKAGE_SKIP: 'rttest tlsf tlsf_cpp pendulum_control msft_colcon_env msft_ros_env msft_ros_pkgs msft_ros_vcpkg'
   steps:
-  - script: |
-      echo %ROSWIN_BUILDNUMBER%
   - template: ..\..\common\agent-prep.yml
   - template: ..\common\checkout.yml
   - template: ..\common\build.yml


### PR DESCRIPTION
Updating `Foxy` and `Eloquent` release snapshots. 
* `Foxy`: `20200710` -> `20200807`
* `Eloquent`: No actual content change. Simply use the correct tag. There was one tag created in a wrong name from the upstream.