### PR TITLE
[noetic] Use dynamic_reconfigure v1.7.1 to workaround dynamic_reconfigure Python3 compatibility.

### DIFF
--- a/experimental/ros/noetic/noetic_override.repos
+++ b/experimental/ros/noetic/noetic_override.repos
@@ -1,4 +1,9 @@
 repositories:
+  dynamic_reconfigure:
+    type: git
+    url: https://github.com/ros/dynamic_reconfigure.git
+    # 1.7.0 has Python3 compatibility issues.
+    version: 1.7.1
   eigenpy:
     type: git
     url: https://github.com/stack-of-tasks/eigenpy.git


### PR DESCRIPTION
This should be able to removed in the next Noetic release sync. This time we hand picked it to unblock downstream packages which consumed the `dynamic_reconfigure` generated C++ headers.