### PR TITLE
[vNext] Normalize the naming convention for the installer EXE.

### DIFF
--- a/experimental/ros/dashing/setup.iss
+++ b/experimental/ros/dashing/setup.iss
@@ -24,7 +24,7 @@ DefaultGroupName={#MyAppName}
 DisableProgramGroupPage=yes
 ; Remove the following line to run in administrative install mode (install for all users.)
 PrivilegesRequired=lowest
-OutputBaseFilename=ros-dashing-setup
+OutputBaseFilename=ros-dashing-setup-x64-{#MyAppVersion}
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern

--- a/experimental/ros/eloquent/setup.iss
+++ b/experimental/ros/eloquent/setup.iss
@@ -24,7 +24,7 @@ DefaultGroupName={#MyAppName}
 DisableProgramGroupPage=yes
 ; Remove the following line to run in administrative install mode (install for all users.)
 PrivilegesRequired=lowest
-OutputBaseFilename=ros-eloquent-setup
+OutputBaseFilename=ros-eloquent-setup-x64-{#MyAppVersion}
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern


### PR DESCRIPTION
Use the same naming convention like what we did for Noetic and Foxy.