### PR TITLE
[Eloquent][Dashing] Ignore cv_bridge camera_calibration_parsers for now

### DIFF
--- a/experimental/ros/azure-pipelines.dashing.release.yml
+++ b/experimental/ros/azure-pipelines.dashing.release.yml
@@ -4,7 +4,7 @@ pr: none
 variables:
   RELEASE_DATE: $[format('{0:yyMMddHHmm}', pipeline.startTime)]
   RELEASE_VERSION: '20200722.0.0.$(RELEASE_DATE)'
-  IGNORED_PACKAGES: 'rttest test_osrf_testing_tools_cpp tlsf cv_bridge'
+  IGNORED_PACKAGES: 'rttest test_osrf_testing_tools_cpp tlsf cv_bridge camera_calibration_parsers'
 
 jobs:
 - job: Build

--- a/experimental/ros/azure-pipelines.eloquent.release.yml
+++ b/experimental/ros/azure-pipelines.eloquent.release.yml
@@ -4,7 +4,7 @@ pr: none
 variables:
   RELEASE_DATE: $[format('{0:yyMMddHHmm}', pipeline.startTime)]
   RELEASE_VERSION: '20200813.0.0.$(RELEASE_DATE)'
-  IGNORED_PACKAGES: 'rttest test_osrf_testing_tools_cpp tlsf cv_bridge'
+  IGNORED_PACKAGES: 'rttest test_osrf_testing_tools_cpp tlsf cv_bridge camera_calibration_parsers'
 
 jobs:
 - job: Build

--- a/experimental/ros/azure-pipelines.eloquent.release.yml
+++ b/experimental/ros/azure-pipelines.eloquent.release.yml
@@ -4,7 +4,7 @@ pr: none
 variables:
   RELEASE_DATE: $[format('{0:yyMMddHHmm}', pipeline.startTime)]
   RELEASE_VERSION: '20200813.0.0.$(RELEASE_DATE)'
-  IGNORED_PACKAGES: 'rttest test_osrf_testing_tools_cpp tlsf'
+  IGNORED_PACKAGES: 'rttest test_osrf_testing_tools_cpp tlsf cv_bridge'
 
 jobs:
 - job: Build


### PR DESCRIPTION
* On Eloquent and Dashing, the cv_bridge is only compatible with OpenCV3. (Our Vcpkg recipe currently is using OpenCV4)
* And there is a build breaks in the camera_calibration_parsers when it tries to include YAML-cpp. The error looks like because there are two copies of YAML-cpp which are not compatible resulting in compile errors. I think we need a back-port of [this](https://github.com/ros2/yaml_cpp_vendor/commit/b11d00fbbe2cd8c8888f8c11ff172e84fdea9adc) for Eloquent and Dashing. For now just disable it to unblock the build.