### PR TITLE
[vNext] Separate the deployment by release types.

### DIFF
--- a/experimental/ros/azure-pipelines.dashing.release.yml
+++ b/experimental/ros/azure-pipelines.dashing.release.yml
@@ -102,11 +102,20 @@ stages:
       ROS_DISTRO: ${{ variables.ROS_DISTRO }}
       RELEASE_VERSION: ${{ variables.RELEASE_VERSION }}
 
-- stage: publish
+- stage: publish_prerelease
   displayName: 'Publish ${{ variables.ROS_DISTRO }}'
   dependsOn:
   - packaging
   jobs:
-  - template: azure-pipelines.publish.yml
+  - template: azure-pipelines.publish.prerelease.yml
+    parameters:
+      ROS_DISTRO: ${{ variables.ROS_DISTRO }}
+
+- stage: publish_release
+  displayName: 'Publish ${{ variables.ROS_DISTRO }}'
+  dependsOn:
+  - packaging
+  jobs:
+  - template: azure-pipelines.publish.release.yml
     parameters:
       ROS_DISTRO: ${{ variables.ROS_DISTRO }}

--- a/experimental/ros/azure-pipelines.dashing.release.yml
+++ b/experimental/ros/azure-pipelines.dashing.release.yml
@@ -103,7 +103,7 @@ stages:
       RELEASE_VERSION: ${{ variables.RELEASE_VERSION }}
 
 - stage: publish_prerelease
-  displayName: 'Publish ${{ variables.ROS_DISTRO }}'
+  displayName: 'Publish Prerelase ${{ variables.ROS_DISTRO }}'
   dependsOn:
   - packaging
   jobs:
@@ -112,7 +112,7 @@ stages:
       ROS_DISTRO: ${{ variables.ROS_DISTRO }}
 
 - stage: publish_release
-  displayName: 'Publish ${{ variables.ROS_DISTRO }}'
+  displayName: 'Publish Release ${{ variables.ROS_DISTRO }}'
   dependsOn:
   - packaging
   jobs:

--- a/experimental/ros/azure-pipelines.eloquent.release.yml
+++ b/experimental/ros/azure-pipelines.eloquent.release.yml
@@ -103,7 +103,7 @@ stages:
       RELEASE_VERSION: ${{ variables.RELEASE_VERSION }}
 
 - stage: publish_prerelease
-  displayName: 'Publish ${{ variables.ROS_DISTRO }}'
+  displayName: 'Publish Prerelease ${{ variables.ROS_DISTRO }}'
   dependsOn:
   - packaging
   jobs:
@@ -112,7 +112,7 @@ stages:
       ROS_DISTRO: ${{ variables.ROS_DISTRO }}
 
 - stage: publish_release
-  displayName: 'Publish ${{ variables.ROS_DISTRO }}'
+  displayName: 'Publish Release ${{ variables.ROS_DISTRO }}'
   dependsOn:
   - packaging
   jobs:

--- a/experimental/ros/azure-pipelines.eloquent.release.yml
+++ b/experimental/ros/azure-pipelines.eloquent.release.yml
@@ -102,11 +102,20 @@ stages:
       ROS_DISTRO: ${{ variables.ROS_DISTRO }}
       RELEASE_VERSION: ${{ variables.RELEASE_VERSION }}
 
-- stage: publish
+- stage: publish_prerelease
   displayName: 'Publish ${{ variables.ROS_DISTRO }}'
   dependsOn:
   - packaging
   jobs:
-  - template: azure-pipelines.publish.yml
+  - template: azure-pipelines.publish.prerelease.yml
+    parameters:
+      ROS_DISTRO: ${{ variables.ROS_DISTRO }}
+
+- stage: publish_release
+  displayName: 'Publish ${{ variables.ROS_DISTRO }}'
+  dependsOn:
+  - packaging
+  jobs:
+  - template: azure-pipelines.publish.release.yml
     parameters:
       ROS_DISTRO: ${{ variables.ROS_DISTRO }}

--- a/experimental/ros/azure-pipelines.foxy.release.yml
+++ b/experimental/ros/azure-pipelines.foxy.release.yml
@@ -101,7 +101,7 @@ stages:
       RELEASE_VERSION: ${{ variables.RELEASE_VERSION }}
 
 - stage: publish_prerelease
-  displayName: 'Publish ${{ variables.ROS_DISTRO }}'
+  displayName: 'Publish Prerelase ${{ variables.ROS_DISTRO }}'
   dependsOn:
   - packaging
   jobs:
@@ -110,7 +110,7 @@ stages:
       ROS_DISTRO: ${{ variables.ROS_DISTRO }}
 
 - stage: publish_release
-  displayName: 'Publish ${{ variables.ROS_DISTRO }}'
+  displayName: 'Publish Release ${{ variables.ROS_DISTRO }}'
   dependsOn:
   - packaging
   jobs:

--- a/experimental/ros/azure-pipelines.foxy.release.yml
+++ b/experimental/ros/azure-pipelines.foxy.release.yml
@@ -100,11 +100,20 @@ stages:
       ROS_DISTRO: ${{ variables.ROS_DISTRO }}
       RELEASE_VERSION: ${{ variables.RELEASE_VERSION }}
 
-- stage: publish
+- stage: publish_prerelease
   displayName: 'Publish ${{ variables.ROS_DISTRO }}'
   dependsOn:
   - packaging
   jobs:
-  - template: azure-pipelines.publish.yml
+  - template: azure-pipelines.publish.prerelease.yml
+    parameters:
+      ROS_DISTRO: ${{ variables.ROS_DISTRO }}
+
+- stage: publish_release
+  displayName: 'Publish ${{ variables.ROS_DISTRO }}'
+  dependsOn:
+  - packaging
+  jobs:
+  - template: azure-pipelines.publish.release.yml
     parameters:
       ROS_DISTRO: ${{ variables.ROS_DISTRO }}

--- a/experimental/ros/azure-pipelines.noetic.release.yml
+++ b/experimental/ros/azure-pipelines.noetic.release.yml
@@ -132,11 +132,20 @@ stages:
       ROS_DISTRO: ${{ variables.ROS_DISTRO }}
       RELEASE_VERSION: ${{ variables.RELEASE_VERSION }}
 
-- stage: publish
+- stage: publish_prerelease
   displayName: 'Publish ${{ variables.ROS_DISTRO }}'
   dependsOn:
   - packaging
   jobs:
-  - template: azure-pipelines.publish.yml
+  - template: azure-pipelines.publish.prerelease.yml
+    parameters:
+      ROS_DISTRO: ${{ variables.ROS_DISTRO }}
+
+- stage: publish_release
+  displayName: 'Publish ${{ variables.ROS_DISTRO }}'
+  dependsOn:
+  - packaging
+  jobs:
+  - template: azure-pipelines.publish.release.yml
     parameters:
       ROS_DISTRO: ${{ variables.ROS_DISTRO }}

--- a/experimental/ros/azure-pipelines.noetic.release.yml
+++ b/experimental/ros/azure-pipelines.noetic.release.yml
@@ -133,7 +133,7 @@ stages:
       RELEASE_VERSION: ${{ variables.RELEASE_VERSION }}
 
 - stage: publish_prerelease
-  displayName: 'Publish ${{ variables.ROS_DISTRO }}'
+  displayName: 'Publish Prerelease ${{ variables.ROS_DISTRO }}'
   dependsOn:
   - packaging
   jobs:
@@ -142,7 +142,7 @@ stages:
       ROS_DISTRO: ${{ variables.ROS_DISTRO }}
 
 - stage: publish_release
-  displayName: 'Publish ${{ variables.ROS_DISTRO }}'
+  displayName: 'Publish Release ${{ variables.ROS_DISTRO }}'
   dependsOn:
   - packaging
   jobs:

--- a/experimental/ros/azure-pipelines.publish.prerelease.yml
+++ b/experimental/ros/azure-pipelines.publish.prerelease.yml
@@ -19,23 +19,3 @@ jobs:
             packagesToPush: '$(Pipeline.Workspace)/$(ROS_DISTRO)-chocolatey-prerelease/*-pre.nupkg'
             publishVstsFeed: 'ros-win/public'
             allowPackageConflicts: true
-- deployment: deploy_release
-  displayName: 'Deploy Release ${{ parameters.ROS_DISTRO }}'
-  pool:
-    vmImage: 'windows-2019'
-  environment: 'nuget-push-release'
-  variables:
-    ROS_DISTRO: '${{ parameters.ROS_DISTRO }}'
-  strategy:
-    runOnce:
-      deploy:
-        steps:
-        - download: current
-          artifact: '$(ROS_DISTRO)-chocolatey'
-        - task: NuGetCommand@2
-          displayName: 'NuGet push'
-          inputs:
-            command: push
-            packagesToPush: '$(Pipeline.Workspace)/$(ROS_DISTRO)-chocolatey/*.nupkg'
-            publishVstsFeed: 'ros-win/public'
-            allowPackageConflicts: true

--- a/experimental/ros/azure-pipelines.publish.prerelease.yml
+++ b/experimental/ros/azure-pipelines.publish.prerelease.yml
@@ -17,5 +17,5 @@ jobs:
           inputs:
             command: push
             packagesToPush: '$(Pipeline.Workspace)/${{ variables.ROS_DISTRO }}-chocolatey-prerelease/*-pre.nupkg'
-            publishVstsFeed: 'ros-win/internal'
+            publishVstsFeed: 'ros-win/public'
             allowPackageConflicts: true

--- a/experimental/ros/azure-pipelines.publish.prerelease.yml
+++ b/experimental/ros/azure-pipelines.publish.prerelease.yml
@@ -11,11 +11,11 @@ jobs:
       deploy:
         steps:
         - download: current
-          artifact: '$(ROS_DISTRO)-chocolatey-prerelease'
+          artifact: '${{ variables.ROS_DISTRO }}-chocolatey-prerelease'
         - task: NuGetCommand@2
           displayName: 'NuGet push'
           inputs:
             command: push
-            packagesToPush: '$(Pipeline.Workspace)/$(ROS_DISTRO)-chocolatey-prerelease/*-pre.nupkg'
-            publishVstsFeed: 'ros-win/public'
+            packagesToPush: '$(Pipeline.Workspace)/${{ variables.ROS_DISTRO }}-chocolatey-prerelease/*-pre.nupkg'
+            publishVstsFeed: 'ros-win/internal'
             allowPackageConflicts: true

--- a/experimental/ros/azure-pipelines.publish.release.yml
+++ b/experimental/ros/azure-pipelines.publish.release.yml
@@ -11,11 +11,11 @@ jobs:
       deploy:
         steps:
         - download: current
-          artifact: '$(ROS_DISTRO)-chocolatey'
+          artifact: '${{ variables.ROS_DISTRO }}-chocolatey'
         - task: NuGetCommand@2
           displayName: 'NuGet push'
           inputs:
             command: push
-            packagesToPush: '$(Pipeline.Workspace)/$(ROS_DISTRO)-chocolatey/*.nupkg'
+            packagesToPush: '$(Pipeline.Workspace)/${{ variables.ROS_DISTRO }}-chocolatey/*.nupkg'
             publishVstsFeed: 'ros-win/public'
             allowPackageConflicts: true

--- a/experimental/ros/azure-pipelines.publish.release.yml
+++ b/experimental/ros/azure-pipelines.publish.release.yml
@@ -1,0 +1,21 @@
+jobs:
+- deployment: deploy_release
+  displayName: 'Deploy Release ${{ parameters.ROS_DISTRO }}'
+  pool:
+    vmImage: 'windows-2019'
+  environment: 'nuget-push-release'
+  variables:
+    ROS_DISTRO: '${{ parameters.ROS_DISTRO }}'
+  strategy:
+    runOnce:
+      deploy:
+        steps:
+        - download: current
+          artifact: '$(ROS_DISTRO)-chocolatey'
+        - task: NuGetCommand@2
+          displayName: 'NuGet push'
+          inputs:
+            command: push
+            packagesToPush: '$(Pipeline.Workspace)/$(ROS_DISTRO)-chocolatey/*.nupkg'
+            publishVstsFeed: 'ros-win/public'
+            allowPackageConflicts: true


### PR DESCRIPTION
Separate the deployment by release types, so approval goes to individual types.