### PR TITLE
[vNext] Correcting the package names from a earlier refactoring

### DIFF
--- a/experimental/ros/azure-pipelines.dashing.release.yml
+++ b/experimental/ros/azure-pipelines.dashing.release.yml
@@ -101,6 +101,7 @@ stages:
       INSTALL_DIR: ${{ variables.INSTALL_DIR }}
       ROS_DISTRO: ${{ variables.ROS_DISTRO }}
       RELEASE_VERSION: ${{ variables.RELEASE_VERSION }}
+      PACKAGE_NAME: 'ros-${{ variables.ROS_DISTRO }}-desktop'
 
 - stage: publish_prerelease
   displayName: 'Publish Prerelase ${{ variables.ROS_DISTRO }}'

--- a/experimental/ros/azure-pipelines.eloquent.release.yml
+++ b/experimental/ros/azure-pipelines.eloquent.release.yml
@@ -101,6 +101,7 @@ stages:
       INSTALL_DIR: ${{ variables.INSTALL_DIR }}
       ROS_DISTRO: ${{ variables.ROS_DISTRO }}
       RELEASE_VERSION: ${{ variables.RELEASE_VERSION }}
+      PACKAGE_NAME: 'ros-${{ variables.ROS_DISTRO }}-desktop'
 
 - stage: publish_prerelease
   displayName: 'Publish Prerelease ${{ variables.ROS_DISTRO }}'

--- a/experimental/ros/azure-pipelines.foxy.release.yml
+++ b/experimental/ros/azure-pipelines.foxy.release.yml
@@ -99,6 +99,7 @@ stages:
       INSTALL_DIR: ${{ variables.INSTALL_DIR }}
       ROS_DISTRO: ${{ variables.ROS_DISTRO }}
       RELEASE_VERSION: ${{ variables.RELEASE_VERSION }}
+      PACKAGE_NAME: 'ros-${{ variables.ROS_DISTRO }}-desktop'
 
 - stage: publish_prerelease
   displayName: 'Publish Prerelase ${{ variables.ROS_DISTRO }}'

--- a/experimental/ros/azure-pipelines.noetic.release.yml
+++ b/experimental/ros/azure-pipelines.noetic.release.yml
@@ -131,6 +131,7 @@ stages:
       INSTALL_DIR: ${{ variables.INSTALL_DIR }}
       ROS_DISTRO: ${{ variables.ROS_DISTRO }}
       RELEASE_VERSION: ${{ variables.RELEASE_VERSION }}
+      PACKAGE_NAME: 'ros-${{ variables.ROS_DISTRO }}-desktop_full'
 
 - stage: publish_prerelease
   displayName: 'Publish Prerelease ${{ variables.ROS_DISTRO }}'

--- a/experimental/ros/azure-pipelines.packaging.yml
+++ b/experimental/ros/azure-pipelines.packaging.yml
@@ -6,6 +6,7 @@ jobs:
     INSTALL_DIR: '${{ parameters.INSTALL_DIR }}'
     ROS_DISTRO: '${{ parameters.ROS_DISTRO }}'
     RELEASE_VERSION: '${{ parameters.RELEASE_VERSION }}'
+    PACKAGE_NAME: '${{ parameters.PACKAGE_NAME }}'
   timeoutInMinutes: 360
   workspace:
     clean: all
@@ -27,13 +28,13 @@ jobs:
       pathtoPublish: '.\experimental\ros\$(ROS_DISTRO)\Output'
       artifactName: '$(ROS_DISTRO)-setup'
   - powershell: |
-      .\experimental\ros\chocolatey\buildChocolatey.ps1 -PackageName "ros-$Env:ROS_DISTRO-desktop_full" -PackageVersion "$Env:RELEASE_VERSION" -SetupProgram ".\experimental\ros\$Env:ROS_DISTRO\Output\ros-$Env:ROS_DISTRO-setup-x64-$Env:RELEASE_VERSION.exe"
+      .\experimental\ros\chocolatey\buildChocolatey.ps1 -PackageName "$Env:PACKAGE_NAME" -PackageVersion "$Env:RELEASE_VERSION" -SetupProgram ".\experimental\ros\$Env:ROS_DISTRO\Output\ros-$Env:ROS_DISTRO-setup-x64-$Env:RELEASE_VERSION.exe"
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: '.\experimental\ros\chocolatey\output'
       artifactName: '$(ROS_DISTRO)-chocolatey'
   - powershell: |
-      .\experimental\ros\chocolatey\buildChocolatey.ps1 -PackageName "ros-$Env:ROS_DISTRO-desktop_full" -PackageVersion "$Env:RELEASE_VERSION-pre" -SetupProgram ".\experimental\ros\$Env:ROS_DISTRO\Output\ros-$Env:ROS_DISTRO-setup-x64-$Env:RELEASE_VERSION.exe"
+      .\experimental\ros\chocolatey\buildChocolatey.ps1 -PackageName "$Env:PACKAGE_NAME" -PackageVersion "$Env:RELEASE_VERSION-pre" -SetupProgram ".\experimental\ros\$Env:ROS_DISTRO\Output\ros-$Env:ROS_DISTRO-setup-x64-$Env:RELEASE_VERSION.exe"
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: '.\experimental\ros\chocolatey\output'


### PR DESCRIPTION
After this pull request (https://github.com/ms-iot/ros-windows-build/pull/134), the package names are getting lost between the changes. This change is to correct it back.