### PR TITLE
[vNext][Melodic] Adding the SDF_PATH.

### DIFF
--- a/experimental/ros/melodic/patch/etc/catkin/profile.d/999.sdformat.bat
+++ b/experimental/ros/melodic/patch/etc/catkin/profile.d/999.sdformat.bat
@@ -1,0 +1,1 @@
+set SDF_PATH=c:\opt\ros\melodic\x64\share\sdformat\1.6


### PR DESCRIPTION
`SDF_PATH` is required after the `sdformat` binary relocation.