### PR TITLE
[vnext][noetic] Adding msft_ros_env for colcon\catkin hooks.

### DIFF
--- a/experimental/ros/azure-pipelines.noetic.release.yml
+++ b/experimental/ros/azure-pipelines.noetic.release.yml
@@ -68,7 +68,6 @@ stages:
         vcs import --force --shallow --recursive src < %Build_SourcesDirectory%\experimental\ros\gazebo.rosinstall
         vcs import --force --shallow --recursive src < %Build_SourcesDirectory%\experimental\ros\noetic\noetic.repos
         vcs import --force --shallow --recursive src < %Build_SourcesDirectory%\experimental\ros\noetic\noetic_override.repos
-        xcopy /Y /S /I %Build_SourcesDirectory%\experimental\ros\src_patch src
         call %Build_SourcesDirectory%\experimental\ros\noetic\build.bat
       displayName: 'Build noetic'
     - task: PublishBuildArtifacts@1

--- a/experimental/ros/noetic/build.bat
+++ b/experimental/ros/noetic/build.bat
@@ -1,5 +1,7 @@
 @echo OFF
 
+xcopy /Y /S /I %Build_SourcesDirectory%\experimental\ros\noetic\src src
+
 set "IGNORED_PACKAGES=stage stage_ros image_view theora_image_transport rviz_plugin_tutorials four_wheel_steering_controller"
 
 colcon build ^

--- a/experimental/ros/noetic/pre-patch/etc/catkin/profile.d/999.sdformat.bat
+++ b/experimental/ros/noetic/pre-patch/etc/catkin/profile.d/999.sdformat.bat
@@ -1,1 +1,0 @@
-set SDF_PATH=c:\opt\ros\noetic\x64\share\sdformat\1.6

--- a/experimental/ros/noetic/src/gazebo/gazebo10/colcon.pkg
+++ b/experimental/ros/noetic/src/gazebo/gazebo10/colcon.pkg
@@ -1,0 +1,3 @@
+{
+    "name": "Gazebo"
+}

--- a/experimental/ros/noetic/src/gazebo_ros_pkgs/gazebo_dev/colcon.pkg
+++ b/experimental/ros/noetic/src/gazebo_ros_pkgs/gazebo_dev/colcon.pkg
@@ -1,0 +1,3 @@
+{
+  "dependencies": ["Gazebo"],
+}

--- a/experimental/ros/noetic/src/msft_ros_env/CMakeLists.txt
+++ b/experimental/ros/noetic/src/msft_ros_env/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(msft_ros_env)
+find_package(catkin REQUIRED)
+
+catkin_package()
+
+set(ROS_VERSION "1")
+set(ROS_PYTHON_VERSION "3")
+set(ROS_DISTRO "noetic")
+
+set(
+  hooks
+  "sdformat"
+  "vcpkg"
+)
+foreach(hook ${hooks})
+  catkin_add_env_hooks("${hook}" SHELLS "bat" DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks)
+endforeach()

--- a/experimental/ros/noetic/src/msft_ros_env/LICENSE
+++ b/experimental/ros/noetic/src/msft_ros_env/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/experimental/ros/noetic/src/msft_ros_env/env-hooks/sdformat.bat.in
+++ b/experimental/ros/noetic/src/msft_ros_env/env-hooks/sdformat.bat.in
@@ -1,0 +1,4 @@
+REM generated from msft_ros_env/env-hooks/sdformat.bat.in
+@echo OFF
+
+set SDF_PATH=c:\opt\ros\noetic\x64\share\sdformat\1.6

--- a/experimental/ros/noetic/src/msft_ros_env/env-hooks/vcpkg.bat.in
+++ b/experimental/ros/noetic/src/msft_ros_env/env-hooks/vcpkg.bat.in
@@ -1,3 +1,4 @@
+REM generated from msft_ros_env/env-hooks/vcpkg.bat.in
 @echo off
 
 :: initialize Vcpkg environments

--- a/experimental/ros/noetic/src/msft_ros_env/package.xml
+++ b/experimental/ros/noetic/src/msft_ros_env/package.xml
@@ -1,0 +1,9 @@
+<package>
+  <name>msft_ros_env</name>
+  <version>0.0.2</version>
+  <description>The package adds additonal environment variables for ROS on Windows.</description>
+  <maintainer email="seanyen@microsoft.com">Sean Yen</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+</package>


### PR DESCRIPTION
`Colcon` is discovering the catkin hooks in a different path. Opposing to just drop the hooks file in `etc/catkin/profile.d`,  adding those hooks by `catkin` package can make those hooks get injected into the proper location by the build tool.