### PR TITLE
[Noetic] Patch rosbridge dependencies.

### DIFF
--- a/experimental/ros/noetic/build.bat
+++ b/experimental/ros/noetic/build.bat
@@ -61,6 +61,15 @@ if errorlevel 1 exit 1
 move /Y %INSTALL_DIR%\Lib\rosparam_shortcuts\rosparam_shortcuts.dll %INSTALL_DIR%\bin
 if errorlevel 1 exit 1
 
+DEL /F /Q %INSTALL_DIR%\Lib\rosbridge_server\rosbridge_tcp
+if errorlevel 1 exit 1
+
+DEL /F /Q %INSTALL_DIR%\Lib\rosbridge_server\rosbridge_udp
+if errorlevel 1 exit 1
+
+DEL /F /Q %INSTALL_DIR%\Lib\rosbridge_server\rosbridge_websocket
+if errorlevel 1 exit 1
+
 :: run rosdep check
 set ROS_ETC_DIR=%INSTALL_DIR%\etc\ros
 rosdep check --from-paths "%INSTALL_DIR%\share" --ignore-src 2>&1

--- a/experimental/ros/noetic/patch.bat
+++ b/experimental/ros/noetic/patch.bat
@@ -3,6 +3,9 @@
 xcopy /Y /S /I .\experimental\ros\%ROS_DISTRO%\pre-patch %INSTALL_DIR%
 set PATH=%INSTALL_DIR%\Scripts;%INSTALL_DIR%;%INSTALL_DIR%\bin;%PATH%
 
+set INCLUDE=C:\opt\ros\noetic\x64\include\python3.8
+set LIB=C:\opt\ros\noetic\x64\Lib
+
 python -m pip config set global.disable-pip-version-check True
 python -m pip install -U pycryptodomex==3.9.8
 python -m pip install -U gnupg==2.3.1
@@ -15,6 +18,16 @@ python -m pip install -U pyassimp==4.1.4
 python -m pip install -U Sphinx==3.2.1
 python -m pip install -U cairocffi==1.1.0
 python -m pip install -U git+https://github.com/ms-iot/rosdep@windows/0.19.0
+
+:: rosbridge related dependencies
+:: https://github.com/RobotWebTools/rosbridge_suite/issues/198
+:: python -m pip install -U bson==0.5.10
+python -m pip install -U pymongo==3.11.0
+python -m pip install -U pyproj==2.6.1.post1
+python -m pip install -U twisted==20.3.0
+python -m pip install -U autobahn==20.7.1
+python -m pip install -U pyOpenSSL==19.1.0
+python -m pip install -U service-identity==18.1.0
 
 :: bootstrap rosdep
 set ROS_ETC_DIR=%INSTALL_DIR%\etc\ros

--- a/experimental/ros/noetic/patch.bat
+++ b/experimental/ros/noetic/patch.bat
@@ -28,6 +28,7 @@ python -m pip install -U twisted==20.3.0
 python -m pip install -U autobahn==20.7.1
 python -m pip install -U pyOpenSSL==19.1.0
 python -m pip install -U service-identity==18.1.0
+python -m pip install -U tornado==6.0.4
 
 :: bootstrap rosdep
 set ROS_ETC_DIR=%INSTALL_DIR%\etc\ros

--- a/experimental/ros/noetic/pre-patch/etc/ros/rosdep/windows.yaml
+++ b/experimental/ros/noetic/pre-patch/etc/ros/rosdep/windows.yaml
@@ -206,6 +206,10 @@ python-argparse:
       packages: [argparse]
 python3:
   windows: []
+python3-autobahn:
+  windows:
+    pip:
+      packages: [autobahn]
 python3-bson:
   windows:
     pip:

--- a/experimental/ros/noetic/pre-patch/etc/ros/rosdep/windows.yaml
+++ b/experimental/ros/noetic/pre-patch/etc/ros/rosdep/windows.yaml
@@ -50,6 +50,8 @@ gtest:
   windows: []
 gtk3:
   windows: []
+libblas-dev:
+  windows: []
 libboost-dev:
   windows: []
 libboost-chrono-dev:
@@ -380,6 +382,10 @@ python3-setuptools:
   windows:
     pip:
       packages: [setuptools]
+python3-tornado:
+  windows:
+    pip:
+      packages: [tornado]
 python3-twisted:
   windows:
     pip:

--- a/experimental/ros/noetic/pre-patch/etc/ros/rosdep/windows.yaml
+++ b/experimental/ros/noetic/pre-patch/etc/ros/rosdep/windows.yaml
@@ -74,6 +74,8 @@ libboost-regex-dev:
   windows: []
 libboost-system-dev:
   windows: []
+libboost-thread:
+  windows: []
 libboost-thread-dev:
   windows: []
 libcairo2-dev:
@@ -202,6 +204,10 @@ python-argparse:
       packages: [argparse]
 python3:
   windows: []
+python3-bson:
+  windows:
+    pip:
+      packages: [pymongo]
 python3-cairo:
   windows:
     pip:
@@ -238,10 +244,18 @@ python3-gnupg:
   windows:
     pip:
       packages: [gnupg]
+python3-pyassimp:
+  windows:
+    pip:
+      packages: [pyassimp]
 python3-pygraphviz:
   windows:
     pip:
       packages: [pygraphviz]
+python3-pyproj:
+  windows:
+    pip:
+      packages: [pyproj]
 python3-ifcfg:
   windows:
     pip:
@@ -366,6 +380,10 @@ python3-setuptools:
   windows:
     pip:
       packages: [setuptools]
+python3-twisted:
+  windows:
+    pip:
+      packages: [twisted]
 python3-wxgtk4.0:
   windows:
     pip:
@@ -381,6 +399,8 @@ qtbase5-dev:
 sdl:
   windows: []
 sdl-image:
+  windows: []
+suitesparse:
   windows: []
 tango-icon-theme:
   windows: [] # we don't have this on Windows


### PR DESCRIPTION
* Add rosbridge related dependencies.
* Edit the `rosdep\windows.yaml` to reflect the mapping.
* Remove some Linux-specific bash scripts under `%INSTALL_DIR%\Lib\rosbridge_server\` which confused the roslaunch on what to run.