### PR TITLE
removed moveit from noetic_override.repos

### DIFF
--- a/ros/noetic/noetic_override.repos
+++ b/ros/noetic/noetic_override.repos
@@ -68,10 +68,6 @@ repositories:
     type: git
     url: https://github.com/ms-iot/gazebo_ros_pkgs.git
     version: windows/2.9.1
-  moveit:
-    type: git
-    url: https://github.com/ms-iot/moveit.git
-    version: windows/1.1.1
   cartographer:
     type: git
     url: https://github.com/ms-iot/cartographer.git


### PR DESCRIPTION
Moveit 1.1.1 in noetic_override.repos was overriding 1.1.5 in the main repos file.